### PR TITLE
fix: prevent Cmd+S silent failure on first press

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -52,7 +52,10 @@ function App() {
 
   const handleSave = useCallback(async () => {
     const markdown = editorRef.current?.getMarkdown();
-    if (markdown === undefined) return;
+    if (markdown === undefined) {
+      console.warn("Save skipped: editor not ready");
+      return;
+    }
 
     if (!path) {
       handleSaveAs(markdown);

--- a/ui/__tests__/components/Editor.test.tsx
+++ b/ui/__tests__/components/Editor.test.tsx
@@ -1,0 +1,98 @@
+import { createRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EditorHandle } from "../../components/Editor";
+
+// --- Milkdown mocks ---
+
+const mockGetInstance = vi.fn();
+const mockUseInstance = vi.fn(() => [false, mockGetInstance]);
+const mockUseEditor = vi.fn();
+
+vi.mock("@milkdown/react", () => ({
+  Milkdown: () => null,
+  MilkdownProvider: ({ children }: { children: React.ReactNode }) => children,
+  useEditor: (...args: unknown[]) => mockUseEditor(...args),
+  useInstance: () => mockUseInstance(),
+}));
+
+vi.mock("@milkdown/crepe", () => ({
+  Crepe: vi.fn(),
+  CrepeFeature: {
+    CodeMirror: "code-mirror",
+    Toolbar: "toolbar",
+    BlockEdit: "block-edit",
+    LinkTooltip: "link-tooltip",
+    ImageBlock: "image-block",
+    Table: "table",
+    ListItem: "list-item",
+    Placeholder: "placeholder",
+    Cursor: "cursor",
+    Latex: "latex",
+  },
+}));
+
+vi.mock("@milkdown/utils", () => ({
+  getMarkdown: () => "getMarkdown-action",
+}));
+
+vi.mock("@milkdown/crepe/theme/common/style.css", () => ({}));
+vi.mock("../../theme/skriv.css", () => ({}));
+
+// Import after mocks are set up
+import { MarkdownEditor } from "../../components/Editor";
+import { render } from "@testing-library/react";
+
+describe("Editor ref.getMarkdown()", () => {
+  beforeEach(() => {
+    mockGetInstance.mockReset();
+    mockUseInstance.mockReset();
+    mockUseEditor.mockReset();
+    mockUseInstance.mockReturnValue([false, mockGetInstance]);
+  });
+
+  it("returns markdown when editor instance is available", () => {
+    const mockEditor = {
+      action: vi.fn().mockReturnValue("# Hello"),
+    };
+    mockGetInstance.mockReturnValue(mockEditor);
+
+    const ref = createRef<EditorHandle>();
+    render(<MarkdownEditor ref={ref} defaultValue="" />);
+
+    const result = ref.current!.getMarkdown();
+
+    expect(result).toBe("# Hello");
+    expect(mockEditor.action).toHaveBeenCalledWith("getMarkdown-action");
+  });
+
+  it("returns undefined when editor instance is not available", () => {
+    mockGetInstance.mockReturnValue(undefined);
+
+    const ref = createRef<EditorHandle>();
+    render(<MarkdownEditor ref={ref} defaultValue="" />);
+
+    const result = ref.current!.getMarkdown();
+
+    expect(result).toBeUndefined();
+  });
+
+  it("reads getInstance at call time, not at render time", () => {
+    // Start with no editor instance (simulates loading state)
+    mockGetInstance.mockReturnValue(undefined);
+
+    const ref = createRef<EditorHandle>();
+    render(<MarkdownEditor ref={ref} defaultValue="" />);
+
+    // First call: editor not ready
+    expect(ref.current!.getMarkdown()).toBeUndefined();
+
+    // Editor becomes available (getInstance reads from a ref internally)
+    const mockEditor = {
+      action: vi.fn().mockReturnValue("# Now ready"),
+    };
+    mockGetInstance.mockReturnValue(mockEditor);
+
+    // Same ref handle, but getInstance now returns the editor
+    expect(ref.current!.getMarkdown()).toBe("# Now ready");
+  });
+});

--- a/ui/components/Editor.tsx
+++ b/ui/components/Editor.tsx
@@ -49,15 +49,18 @@ const CrepeEditor = forwardRef<EditorHandle, EditorProps>(({ defaultValue, onCha
     [defaultValue]
   );
 
-  const [loading, getInstance] = useInstance();
+  const [, getInstance] = useInstance();
 
-  useImperativeHandle(ref, () => ({
-    getMarkdown: () => {
-      if (loading) return undefined;
-      const editor = getInstance();
-      return editor?.action(getMarkdown());
-    },
-  }));
+  useImperativeHandle(
+    ref,
+    () => ({
+      getMarkdown: () => {
+        const editor = getInstance();
+        return editor?.action(getMarkdown());
+      },
+    }),
+    [getInstance]
+  );
 
   return <Milkdown />;
 });


### PR DESCRIPTION
Closes #15

## Summary
- Removed stale `loading` closure check from `useImperativeHandle` in `Editor.tsx` — `getInstance()` already reads from a ref at call time, so it always returns the current editor (or `undefined` if not ready). The optional chaining handles both cases correctly.
- Added proper `[getInstance]` dependency array to `useImperativeHandle` so the ref handle is explicit about when it updates.
- Added `console.warn` in `handleSave` (`App.tsx`) when save is skipped due to editor not being ready, so the failure is no longer completely silent.

## Test plan
- [x] Open a markdown file and press Cmd+S once — file should save on the first press
- [x] Verify no regressions with Save As (Cmd+Shift+S) or Open (Cmd+O)
- [x] Check browser console for "Save skipped: editor not ready" warning if save is attempted before editor loads