### PR TITLE
fix: debounce file watcher and auto-reload clean files (#16)

### DIFF
--- a/docs/plans/2026-03-19-file-watcher-debounce-design.md
+++ b/docs/plans/2026-03-19-file-watcher-debounce-design.md
@@ -1,0 +1,41 @@
+# File Watcher Debounce & Auto-Reload
+
+**Issue:** [#16 — File watcher triggers multiple reload popups for a single external edit](https://github.com/bhendo/skriv/issues/16)
+**Date:** 2026-03-19
+
+## Problem
+
+When an external process modifies the currently open file, the OS emits multiple filesystem events for a single logical write. Each event triggers a blocking `confirm()` dialog, creating a rapid-fire popup loop that forces the user to click through many dialogs.
+
+## Design
+
+### Backend: Debounced file watcher (`watcher.rs`)
+
+When a `Modify` event arrives, start/reset a 300ms timer. Only emit `"file-changed"` after 300ms of quiet. This collapses any burst of OS events into a single Tauri event emission.
+
+A dedicated thread owns the timer. The `notify` callback signals that thread (via `mpsc` or atomic flag), which resets its countdown on each signal. When the countdown expires, it checks self-write suppression and emits the Tauri event.
+
+The existing self-write suppression (`last_self_write` / `SELF_WRITE_SUPPRESSION_MS`) stays as-is, checked before emitting in the debounce thread.
+
+### Frontend: Auto-reload when clean, banner when dirty (`App.tsx`)
+
+When `"file-changed"` arrives:
+
+- If `isModified` is **false** — silently call `openFile(path)` to reload. No prompt.
+- If `isModified` is **true** — show a non-blocking `ReloadBanner` (modeled after `ErrorBanner`) with "File changed on disk" and Reload / Dismiss buttons.
+
+The blocking `confirm()` call is removed entirely.
+
+### Testing
+
+- **Rust unit test:** Verify debounce logic — multiple rapid signals result in a single emission after the quiet period.
+- **Frontend unit test:** Verify auto-reload when `isModified` is false, and banner display when `isModified` is true.
+
+## Decisions
+
+| Decision | Rationale |
+|---|---|
+| Backend debounce, not frontend | Rust owns file management; solves the problem at the source and reduces IPC noise |
+| 300ms debounce window | Long enough to coalesce typical write bursts, short enough to feel responsive |
+| Auto-reload when unmodified | Matches Typora behavior — no unnecessary prompts |
+| Non-blocking banner when modified | Prevents the `confirm()` queue-and-block loop |

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -5,11 +5,13 @@ use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 const SELF_WRITE_SUPPRESSION_MS: u64 = 1000;
+const DEBOUNCE_MS: u64 = 300;
 
 pub struct FileWatcher {
     watcher: Mutex<Option<RecommendedWatcher>>,
     watched_path: Mutex<Option<PathBuf>>,
     last_self_write: Arc<Mutex<Option<Instant>>>,
+    debounce_tx: Mutex<Option<std::sync::mpsc::Sender<()>>>,
 }
 
 impl FileWatcher {
@@ -18,6 +20,7 @@ impl FileWatcher {
             watcher: Mutex::new(None),
             watched_path: Mutex::new(None),
             last_self_write: Arc::new(Mutex::new(None)),
+            debounce_tx: Mutex::new(None),
         }
     }
 
@@ -36,19 +39,28 @@ impl FileWatcher {
         let emit_path = canonical.to_string_lossy().into_owned();
         let last_self_write_ref = self.last_self_write.clone();
 
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        // Spawn debounce thread
+        std::thread::spawn(move || {
+            run_debounce_loop(rx, Duration::from_millis(DEBOUNCE_MS), move || {
+                let suppress = {
+                    let last = last_self_write_ref.lock().unwrap();
+                    last.is_some_and(|t| {
+                        t.elapsed() < Duration::from_millis(SELF_WRITE_SUPPRESSION_MS)
+                    })
+                };
+                if !suppress {
+                    let _ = app_handle.emit("file-changed", &emit_path);
+                }
+            });
+        });
+
+        let tx_clone = tx.clone();
         let mut watcher = recommended_watcher(move |res: Result<Event, _>| {
             if let Ok(event) = res {
                 if matches!(event.kind, EventKind::Modify(_)) {
-                    let suppress = {
-                        let last = last_self_write_ref.lock().unwrap();
-                        last.is_some_and(|t| {
-                            t.elapsed() < Duration::from_millis(SELF_WRITE_SUPPRESSION_MS)
-                        })
-                    };
-
-                    if !suppress {
-                        let _ = app_handle.emit("file-changed", &emit_path);
-                    }
+                    let _ = tx_clone.send(());
                 }
             }
         })
@@ -60,6 +72,7 @@ impl FileWatcher {
 
         *self.watcher.lock().unwrap() = Some(watcher);
         *self.watched_path.lock().unwrap() = Some(canonical);
+        *self.debounce_tx.lock().unwrap() = Some(tx);
 
         Ok(())
     }
@@ -74,7 +87,103 @@ impl FileWatcher {
 
         *watcher = None;
         *watched = None;
+        *self.debounce_tx.lock().unwrap() = None; // drops sender, terminates debounce thread
 
         Ok(())
+    }
+}
+
+/// Debounce loop: waits for signals on `rx`, then waits for `quiet_period` of
+/// silence before calling `on_emit`. Exits when the sender is dropped.
+fn run_debounce_loop(
+    rx: std::sync::mpsc::Receiver<()>,
+    quiet_period: Duration,
+    mut on_emit: impl FnMut(),
+) {
+    loop {
+        // Block until first event (or sender dropped)
+        if rx.recv().is_err() {
+            break;
+        }
+        // Consume rapid follow-up events until quiet
+        loop {
+            match rx.recv_timeout(quiet_period) {
+                Ok(()) => continue,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+            }
+        }
+        on_emit();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+
+    #[test]
+    fn debounce_coalesces_rapid_signals() {
+        let (tx, rx) = mpsc::channel();
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_clone = count.clone();
+
+        let handle = std::thread::spawn(move || {
+            run_debounce_loop(rx, Duration::from_millis(50), move || {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+
+        // Send 5 rapid signals
+        for _ in 0..5 {
+            tx.send(()).unwrap();
+        }
+        // Wait for debounce to fire
+        std::thread::sleep(Duration::from_millis(150));
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+
+        drop(tx);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn debounce_fires_separately_for_spaced_bursts() {
+        let (tx, rx) = mpsc::channel();
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_clone = count.clone();
+
+        let handle = std::thread::spawn(move || {
+            run_debounce_loop(rx, Duration::from_millis(50), move || {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+
+        // First burst
+        tx.send(()).unwrap();
+        std::thread::sleep(Duration::from_millis(150));
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+
+        // Second burst
+        tx.send(()).unwrap();
+        std::thread::sleep(Duration::from_millis(150));
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+
+        drop(tx);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn debounce_exits_when_sender_dropped() {
+        let (tx, rx) = mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            run_debounce_loop(rx, Duration::from_millis(50), || {});
+        });
+
+        drop(tx);
+        // Thread should exit promptly
+        handle.join().unwrap();
     }
 }

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { MarkdownEditor, type EditorHandle } from "./components/Editor";
 import { ErrorBanner } from "./components/ErrorBanner";
+import { ReloadBanner } from "./components/ReloadBanner";
 import { useFile } from "./hooks/useFile";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useTheme } from "./hooks/useTheme";
@@ -30,6 +31,12 @@ function App() {
   } = useFile();
 
   useTheme();
+
+  const [showReloadBanner, setShowReloadBanner] = useState(false);
+  const isModifiedRef = useRef(isModified);
+  useEffect(() => {
+    isModifiedRef.current = isModified;
+  }, [isModified]);
 
   const handleChange = useCallback(() => {
     markModified();
@@ -105,7 +112,9 @@ function App() {
   // Listen for external file changes on disk
   useEffect(() => {
     const unlisten = listen<string>("file-changed", () => {
-      if (confirm("File changed on disk. Reload?")) {
+      if (isModifiedRef.current) {
+        setShowReloadBanner(true);
+      } else {
         if (path) openFile(path);
       }
     });
@@ -114,9 +123,23 @@ function App() {
     };
   }, [path, openFile]);
 
+  // Clear reload banner when a new file is opened or reloaded
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronizing banner visibility with file state
+    setShowReloadBanner(false);
+  }, [path, content]);
+
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
       <ErrorBanner message={error} onDismiss={clearError} />
+      <ReloadBanner
+        visible={showReloadBanner}
+        onReload={() => {
+          setShowReloadBanner(false);
+          if (path) openFile(path);
+        }}
+        onDismiss={() => setShowReloadBanner(false)}
+      />
       <div style={{ flex: 1, overflow: "auto" }}>
         <MarkdownEditor
           ref={editorRef}

--- a/ui/__tests__/components/ReloadBanner.test.tsx
+++ b/ui/__tests__/components/ReloadBanner.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReloadBanner } from "../../components/ReloadBanner";
+
+describe("ReloadBanner", () => {
+  afterEach(cleanup);
+
+  it("renders nothing when visible is false", () => {
+    const { container } = render(
+      <ReloadBanner visible={false} onReload={vi.fn()} onDismiss={vi.fn()} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the banner when visible is true", () => {
+    render(<ReloadBanner visible={true} onReload={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.queryByText(/file changed on disk/i)).not.toBeNull();
+  });
+
+  it("calls onReload when Reload is clicked", async () => {
+    const onReload = vi.fn();
+    render(<ReloadBanner visible={true} onReload={onReload} onDismiss={vi.fn()} />);
+    await userEvent.click(screen.getByRole("button", { name: /reload/i }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDismiss when Dismiss is clicked", async () => {
+    const onDismiss = vi.fn();
+    render(<ReloadBanner visible={true} onReload={vi.fn()} onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/components/ReloadBanner.tsx
+++ b/ui/components/ReloadBanner.tsx
@@ -1,0 +1,57 @@
+import { type FC } from "react";
+
+interface ReloadBannerProps {
+  visible: boolean;
+  onReload: () => void;
+  onDismiss: () => void;
+}
+
+export const ReloadBanner: FC<ReloadBannerProps> = ({ visible, onReload, onDismiss }) => {
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        backgroundColor: "var(--crepe-color-surface-low, #fffbeb)",
+        borderBottom: "1px solid var(--crepe-color-outline, #fde68a)",
+        color: "var(--crepe-color-on-surface, #92400e)",
+        fontSize: 13,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+      }}
+    >
+      <span>File changed on disk.</span>
+      <div style={{ display: "flex", gap: 8 }}>
+        <button
+          onClick={onReload}
+          style={{
+            background: "none",
+            border: "1px solid currentColor",
+            borderRadius: 4,
+            cursor: "pointer",
+            color: "inherit",
+            fontSize: 12,
+            padding: "2px 8px",
+          }}
+        >
+          Reload
+        </button>
+        <button
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          style={{
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            color: "inherit",
+            fontSize: 16,
+          }}
+        >
+          &#x2715;
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

- **Backend debounce** in `watcher.rs`: coalesces rapid filesystem `Modify` events into a single `"file-changed"` emission after 300ms of quiet, using an mpsc channel + dedicated thread
- **Auto-reload** when file is unmodified: silently reloads from disk with no prompt
- **Non-blocking `ReloadBanner`** when file has unsaved changes: replaces the blocking `confirm()` dialog that caused popup storms
- Removes `confirm()` entirely — no more event queueing behind a synchronous dialog

Closes #16

## Test Plan

- [x] Rust unit tests: debounce coalesces rapid signals, fires separately for spaced bursts, exits on sender drop (3 tests)
- [x] Frontend unit tests: ReloadBanner renders/hides correctly, Reload and Dismiss buttons fire callbacks (4 tests)
- [x] `make check` passes (format, lint, clippy, 38 total tests)
- [x] Manual: open a file, edit externally → auto-reloads without prompt
- [x] Manual: make unsaved changes, edit externally → banner appears with Reload/Dismiss
- [x] Manual: click Reload → file reloads, banner disappears
- [x] Manual: click Dismiss → banner disappears, content unchanged