### PR TITLE
Fix e2e formatting tests for slowMo compatibility

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   use: {
     baseURL: "http://localhost:1420",
     headless: true,
+    launchOptions: {
+      slowMo: Number(process.env.SLOWMO) || 0,
+    },
   },
   webServer: {
     command: "pnpm dev",

--- a/e2e/tests/formatting.spec.ts
+++ b/e2e/tests/formatting.spec.ts
@@ -4,13 +4,13 @@ test.describe("Formatting keyboard shortcuts", () => {
   test("Cmd+B toggles bold on selected text", async ({ page, loadApp }) => {
     await loadApp({
       openedFile: "/tmp/test.md",
-      fileContent: "hello world\n",
+      fileContent: "hello\n",
     });
     const editor = page.locator(".milkdown .editor");
     await editor.click();
 
-    const paragraph = editor.locator("p").first();
-    await paragraph.dblclick();
+    // Select all text with keyboard (deterministic regardless of slowMo)
+    await page.keyboard.press(`${MOD}+a`);
     await page.keyboard.press(`${MOD}+b`);
 
     await expect(editor.locator("strong")).toContainText("hello");
@@ -19,13 +19,12 @@ test.describe("Formatting keyboard shortcuts", () => {
   test("Cmd+I toggles italic on selected text", async ({ page, loadApp }) => {
     await loadApp({
       openedFile: "/tmp/test.md",
-      fileContent: "hello world\n",
+      fileContent: "hello\n",
     });
     const editor = page.locator(".milkdown .editor");
     await editor.click();
 
-    const paragraph = editor.locator("p").first();
-    await paragraph.dblclick();
+    await page.keyboard.press(`${MOD}+a`);
     await page.keyboard.press(`${MOD}+i`);
 
     await expect(editor.locator("em")).toContainText("hello");


### PR DESCRIPTION
## Summary

Fixes flaky formatting tests when running with `SLOWMO` enabled.

- Replace `dblclick()` word selection with `Cmd+a` on single-word content — `dblclick` is non-deterministic with slowMo because the delay between clicks changes which word the browser selects
- Add `SLOWMO` env var support to Playwright config (`launchOptions.slowMo`)

## Usage

```bash
SLOWMO=500 pnpm test:e2e --workers=1 --headed
```

## Test plan

- [x] `pnpm test:e2e` — 20 tests pass in normal mode
- [x] `SLOWMO=500 pnpm test:e2e --workers=1` — 20 tests pass in slowmo mode