### PR TITLE
fix: reject asset protocol scope for files inside sensitive directories

### DIFF
--- a/src-tauri/src/scope.rs
+++ b/src-tauri/src/scope.rs
@@ -3,6 +3,20 @@ use tauri::Manager;
 
 const SENSITIVE_DIRS: &[&str] = &[".ssh", ".gnupg", ".aws", ".config", ".kube"];
 
+/// Check whether any component of `dir` (or `dir` itself) is a sensitive directory.
+fn is_inside_sensitive_dir(dir: &Path) -> bool {
+    for ancestor in dir.ancestors() {
+        if let Some(name) = ancestor.file_name() {
+            if let Some(name_str) = name.to_str() {
+                if SENSITIVE_DIRS.contains(&name_str) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Expand the asset protocol scope to include the parent directory of the opened file.
 /// This is called internally from Rust — never exposed as a Tauri command.
 pub fn expand_scope_for_file(app: &tauri::AppHandle, file_path: &Path) -> Result<(), String> {
@@ -15,6 +29,14 @@ pub fn expand_scope_for_file(app: &tauri::AppHandle, file_path: &Path) -> Result
     // Block root-level directories
     if canonical_dir.parent().is_none() {
         return Err("Cannot scope root directory".into());
+    }
+
+    // Reject if the directory itself is inside a sensitive path
+    if is_inside_sensitive_dir(&canonical_dir) {
+        return Err(format!(
+            "Cannot open files in sensitive directory: {}",
+            canonical_dir.display()
+        ));
     }
 
     let scope = app.asset_protocol_scope();
@@ -31,4 +53,40 @@ pub fn expand_scope_for_file(app: &tauri::AppHandle, file_path: &Path) -> Result
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn detects_direct_sensitive_dir() {
+        assert!(is_inside_sensitive_dir(&PathBuf::from("/home/user/.ssh")));
+        assert!(is_inside_sensitive_dir(&PathBuf::from("/home/user/.gnupg")));
+        assert!(is_inside_sensitive_dir(&PathBuf::from("/home/user/.aws")));
+        assert!(is_inside_sensitive_dir(&PathBuf::from(
+            "/home/user/.config"
+        )));
+        assert!(is_inside_sensitive_dir(&PathBuf::from("/home/user/.kube")));
+    }
+
+    #[test]
+    fn detects_nested_sensitive_dir() {
+        assert!(is_inside_sensitive_dir(&PathBuf::from(
+            "/home/user/.ssh/keys"
+        )));
+        assert!(is_inside_sensitive_dir(&PathBuf::from(
+            "/home/user/.aws/sso/cache"
+        )));
+    }
+
+    #[test]
+    fn allows_normal_directories() {
+        assert!(!is_inside_sensitive_dir(&PathBuf::from("/home/user/docs")));
+        assert!(!is_inside_sensitive_dir(&PathBuf::from(
+            "/home/user/projects/my-app"
+        )));
+        assert!(!is_inside_sensitive_dir(&PathBuf::from("/tmp")));
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes a logic bug where opening a markdown file *inside* a sensitive directory (e.g., `~/.ssh/notes.md`) would add the entire sensitive directory to the asset protocol scope, potentially exposing SSH keys, AWS credentials, etc.
- Adds `is_inside_sensitive_dir()` that walks the full ancestry of the canonical path to reject files living inside `.ssh`, `.gnupg`, `.aws`, `.config`, or `.kube`
- The check runs before `allow_directory`, so the scope is never expanded for sensitive paths

Closes #51

## Test plan

- [x] New unit tests: `detects_direct_sensitive_dir`, `detects_nested_sensitive_dir`, `allows_normal_directories`
- [x] All 18 existing tests pass
- [x] Clippy clean