### PR TITLE
feat: cursor-aware link syntax toggling (#27)

### DIFF
--- a/docs/plans/2026-03-23-link-syntax-toggling-design.md
+++ b/docs/plans/2026-03-23-link-syntax-toggling-design.md
@@ -1,0 +1,314 @@
+# Link Syntax Toggling
+
+**Issue:** [#27](https://github.com/bhendo/skriv/issues/27)
+**Date:** 2026-03-23
+
+## Summary
+
+When the cursor enters a link, reveal the full `[text](url)` markdown syntax inline and allow editing. When the cursor leaves, parse the raw text back into a link mark. Follows Typora's link UX exactly: click enters edit mode, Cmd+click follows the link, Cmd+K inserts raw syntax inline, and typing `[text](url)` creates a link.
+
+## Scope
+
+### In Scope
+
+- Cursor-enter reveals `[text](url)` for existing links
+- Cursor-leave parses raw text back into a link mark
+- Cmd+K creates links inline (no dialog)
+- Typing `[text](url)` converts to a link mark (input rule)
+- Cmd+click follows links (opens in system browser)
+- Same-boundary inner marks within link text (e.g., `[**bold**](url)`)
+- Coexist with Crepe's LinkTooltip (tooltip for hover preview, source mode for editing)
+- Link titles: `[text](url "title")`
+- Serialization safety
+
+### Out of Scope (deferred)
+
+- Different-boundary inner marks within link text (e.g., `[normal **bold**](url)`) — blocked by #31
+- Autolinks (`<https://example.com>`)
+- Reference links (`[text][ref]`)
+- Image syntax (`![alt](url)`)
+
+## Approach: Dedicated `link_source` Node
+
+A new `link_source` ProseMirror node, following the same transient node pattern as `inline_source` but with link-specific parsing and behavior. Reuses shared infrastructure (`makeDecorationPlugin`, `findAncestorOfType`, IME guard pattern) but keeps the state machine and parsing separate.
+
+### Why Not Reuse `inline_source`
+
+Link syntax is structurally different from wrapping marks — it has `[text](url)` with an attribute (`href`) rather than symmetric prefix/suffix markers. Mixing the two models in one node would complicate both the parser and the state machine. The project's established pattern gives each syntax type its own plugin directory (inline-source, heading-source, code-block-source, list-source).
+
+## Design
+
+### Schema: `link_source` Node
+
+```ts
+link_source: {
+  group: "inline",
+  inline: true,
+  content: "text*",
+  marks: "",           // disallow marks inside raw source
+  attrs: {
+    href: { default: "" },
+    title: { default: "" },
+  },
+  toDOM: () => ["span", { class: "link-source" }, 0],
+  parseDOM: [],        // transient — never parsed from HTML/markdown
+}
+```
+
+Key properties:
+
+- Same transient inline node pattern as `inline_source` — only exists while cursor is inside.
+- `marks: ""` prevents formatted content inside the raw text.
+- `href` and `title` attrs store the original link data for serialization safety — if `getMarkdown()` is called mid-edit, the serializer can reconstruct a valid link even if the raw text is in a partial state.
+- The node content is the full raw syntax string: `[display text](url)`.
+
+### State Machine: `appendTransaction`
+
+Same enter/leave pattern as `inline_source`, with link-specific detection.
+
+**Enter (Rendered → Raw):**
+
+1. On selection-only change (no doc change), check if cursor is adjacent to a `link` mark.
+2. Detect the link mark via `$cursor.nodeBefore`/`$cursor.nodeAfter` marks, looking for the `link` mark type specifically.
+3. Find the full extent of the link mark span — walk siblings sharing the same `link` mark with the same `href`.
+4. **Same-boundary inner mark check:** Only enter if all text nodes in the link span share the same set of non-link marks. If mark sets differ across text nodes, don't enter (deferred to #31).
+5. Read the `href` (and `title` if present) from the mark's attrs.
+6. Build raw text: `[textContent](href)` (or `[textContent](href "title")` if title exists). If same-boundary inner marks are present, the text portion is first wrapped with mark syntax via `buildRawText`.
+7. Replace the mark span with a `link_source` node, storing `href`/`title` in node attrs.
+8. Map cursor position: offset in rendered text → offset in raw text (accounting for the `[` prefix, plus inner mark prefix length if applicable).
+9. Transaction uses `addToHistory: false`.
+
+**Leave (Raw → Rendered):**
+
+1. On selection change, check if cursor has moved outside any existing `link_source` node.
+2. Parse raw text content via `parseLinkSyntax` for `[text](url)` (and optionally `[text](url "title")`).
+3. If valid: replace node with text node carrying a `link` mark with `href`/`title` attrs. Inner text is run through `parseInlineSyntax` to recover same-boundary marks.
+4. If invalid (incomplete syntax): replace with plain unmarked text.
+5. If empty: delete the node.
+6. Transaction uses `addToHistory: false`.
+
+**Invariant:** At most one inline source node (`inline_source` OR `link_source`) exists in the document at any time. These are both inline-level nodes and are mutually exclusive. (Note: `heading_source` is a block-level container and can coexist — a `link_source` can be active inside an active `heading_source`, same as `inline_source` can today.)
+
+**Cross-node leave coordination:** Both plugins are responsible for leaving the other:
+
+- **Link-source enter path:** Before creating a `link_source` node, calls `findFirstNodeOfType(doc, "inline_source")` and dispatches `leaveInlineSource` (imported from `inline-source/plugin.ts`, already exported) if found.
+- **Inline-source enter path:** Before creating an `inline_source` node, calls `findFirstNodeOfType(doc, "link_source")` and dispatches `leaveLinkSource` (exported from `link-source/plugin.ts`) if found. This check goes after the `docChanged` guard and before mark detection in `handleInlineSourceTransition`.
+- **Inline-source enter guard for link marks:** Additionally, the inline-source plugin's enter path must skip enter entirely when the cursor is adjacent to a node carrying a `link` mark — this yields to the link-source plugin regardless of plugin registration order. Added before the `SUPPORTED_MARKS` iteration.
+
+Both leave operations happen within the same `appendTransaction` pass as the enter — leave the other node, then enter the new one, all in a single transaction.
+
+### Cursor Detection
+
+Link marks carry attrs, so span detection uses a dedicated `findLinkSpan` function (separate from the existing `findMarkSpan` used by inline-source). Two adjacent links with different `href` values are different spans.
+
+**`findLinkSpan`:** Similar to `findMarkSpan` but additionally compares the `href` attr when walking siblings. Only includes nodes whose `link` mark has the same `href` as the mark at the cursor position.
+
+**Priority with inline marks:** When the cursor is adjacent to text that carries both a `link` mark and other marks, the `link` mark takes priority for enter detection. This is enforced by the check logic in each plugin's `appendTransaction` — the link-source plugin checks for the `link` mark first, and the inline-source plugin skips enter when the cursor is on a `link` mark. This works regardless of plugin registration order.
+
+### Cursor Position Mapping
+
+**Enter:** `[` prefix is 1 char, plus any inner mark prefix length. Offset in raw = offset in rendered + 1 + innerPrefixLength.
+
+**Leave:** Inverse of enter. Offset in rendered = offset in raw − 1 − innerPrefixLength.
+
+Selection is set explicitly via `tr.setSelection(TextSelection.create(tr.doc, computedPos))`.
+
+### Cmd+K: Inline Link Creation
+
+Follows Typora's model:
+
+**Cmd+K with selected text:**
+
+1. Wrap selection as `[selected text]()`.
+2. Replace the selection with a `link_source` node containing that raw string.
+3. Place cursor inside the parens, ready for URL input.
+4. **Clipboard URL auto-fill:** Read the clipboard via `navigator.clipboard.readText()` (async). If the text passes `URL.canParse()` with `http:` or `https:` protocol, auto-fill: `[selected text](clipboard-url)` with cursor at end of URL. If clipboard read fails (permission denied, empty, not a valid URL), fall back to empty parens.
+
+**Cmd+K with no selection:**
+
+1. Insert a `link_source` node containing `[]()`.
+2. Place cursor inside the brackets, ready for text input.
+
+**Cmd+K when cursor is already inside a `link_source`:** No-op.
+
+**Cmd+K when cursor is on an existing rendered link:** Triggers enter (same as cursor-enter).
+
+Intercepted in the plugin's `handleKeyDown`, same pattern as Cmd+B/I shortcuts in `inline_source`.
+
+### Input Rule: Typed Link Syntax
+
+When the user types `[text](url)` as plain text, it converts to a link mark.
+
+**Trigger:** An input rule matching `\[([^\]]+)\]\(([^)]+)\)` at the cursor position. Fires when the closing `)` is typed. The character classes exclude `]` and `)` respectively to prevent greedy over-matching across multiple links (e.g., `[foo](bar) and [baz](qux)` must not match as a single link). Nested brackets in the text portion (e.g., `[text [with] brackets](url)`) are not supported in v1.
+
+**Behavior:**
+
+1. On match, replace the raw text with a text node carrying a `link` mark with `href` set to the captured URL.
+2. Inner text is parsed through `parseInlineSyntax` for same-boundary marks (so typing `[**bold**](url)` produces a bold link).
+3. This is a real document edit — goes into history (unlike enter/leave transitions).
+
+The input rule must NOT fire inside a `link_source` node. The plugin's `handleTextInput` bypass intercepts all text input inside `link_source` and dispatches it directly, which prevents both Milkdown's built-in input rules AND this spec's own link input rule from triggering on `)` typed while already editing a link.
+
+### Cmd+Click: Follow Link
+
+When `syntaxToggling` is on:
+
+- Regular click on a link → cursor enters, reveals raw syntax.
+- Cmd+click on a link → open the URL in the system browser via Tauri's shell API. Returns `true` to prevent cursor placement.
+
+When `syntaxToggling` is off:
+
+- LinkTooltip is active, handles link interaction as it does today.
+
+Implemented in the plugin's `handleClick` prop, checking `event.metaKey` (or `event.ctrlKey` on non-Mac).
+
+### LinkTooltip Coexistence
+
+Crepe's `LinkTooltip` remains enabled regardless of `syntaxToggling`. The two features cannot conflict because they target different states — the tooltip attaches to a rendered `link` mark, which is replaced by a `link_source` node when source mode activates. The tooltip naturally disappears when its target is gone.
+
+- **Hover** → tooltip shows URL + edit/remove buttons
+- **Click tooltip edit** → cursor enters link → source mode activates → tooltip disappears
+- **Click tooltip remove** → link mark removed, plain text remains (no source mode involved)
+- **Click link text directly** → cursor enters → source mode activates → tooltip disappears
+
+No changes to `Editor.tsx` feature configuration needed for LinkTooltip.
+
+### Parsing & Serialization
+
+**`parseLinkSyntax(raw: string)`:**
+
+```ts
+parseLinkSyntax("[**bold**](https://example.com)")
+// → { text: "**bold**", href: "https://example.com", title: "", innerMarks: ["strong"] }
+
+parseLinkSyntax("[text](url \"My Title\")")
+// → { text: "text", href: "url", title: "My Title", innerMarks: [] }
+
+parseLinkSyntax("[incomplete")
+// → null (invalid — degrades to plain text)
+```
+
+Rules:
+
+- Must have `[`, `]`, `(`, `)` in the correct structure.
+- Text between `[` and `]` must be non-empty.
+- URL between `(` and `)` must be non-empty.
+- Both parts non-empty = valid link. Either part empty = plain text (including `[text]()` and `[](url)`).
+- Title is optional, parsed from `"title"` after the URL inside parens. Milkdown's commonmark `link` mark schema includes a `title` attribute. v1 simplification: only double-quoted titles are supported; escaped quotes inside titles and single-quote delimiters are not handled.
+- Inner text is run through existing `parseInlineSyntax` to recover same-boundary marks.
+
+**`buildLinkRawText(text: string, href: string, title?: string)`:**
+
+```ts
+buildLinkRawText("bold", "https://example.com")
+// → "[bold](https://example.com)"
+
+buildLinkRawText("bold", "https://example.com", "My Title")
+// → "[bold](https://example.com \"My Title\")"
+```
+
+When entering a link with same-boundary inner marks, the text portion is first run through `buildRawText` to wrap it with mark syntax before wrapping with link syntax.
+
+**Serialization safety (toMarkdown):**
+
+```ts
+toMarkdown: {
+  match: (node) => node.type.name === "link_source",
+  runner: (state, node) => {
+    const raw = node.textContent;
+    const parsed = parseLinkSyntax(raw);
+    if (parsed) {
+      // Raw text is valid link syntax — serialize from parsed content
+      state.openNode("link", { url: parsed.href, title: parsed.title || undefined });
+      // Handle inner marks on the text portion
+      const innerParsed = parseInlineSyntax(parsed.text);
+      if (innerParsed.marks.length > 0) {
+        for (const markName of innerParsed.marks) {
+          const remarkType = MARK_SYNTAX[markName]?.remarkType ?? markName;
+          state.openNode(remarkType);
+        }
+        state.addNode("text", undefined, innerParsed.text);
+        for (let i = innerParsed.marks.length - 1; i >= 0; i--) {
+          state.closeNode();
+        }
+      } else {
+        state.addNode("text", undefined, parsed.text);
+      }
+      state.closeNode();
+    } else if (node.attrs.href) {
+      // Raw text is invalid but we have attrs — serialize from attrs
+      state.openNode("link", { url: node.attrs.href, title: node.attrs.title || undefined });
+      state.addNode("text", undefined, raw || node.attrs.href);
+      state.closeNode();
+    } else {
+      // No valid link data — serialize as plain text
+      state.addNode("text", undefined, raw);
+    }
+  },
+}
+```
+
+### Trailing Split
+
+A dedicated `findLinkTrailingSplit` function detects text trailing after closed link syntax. Unlike `inline_source`'s `findTrailingSplit` which scans for symmetric prefix/suffix markers, the link version scans for the `](...)` closing sequence followed by additional characters.
+
+For example, `[text](url) and more`:
+- Link portion: `[text](url)` → becomes a rendered link mark
+- Trailing: ` and more` → becomes plain text
+
+The function first checks if the full string is a valid closed link pattern via `parseLinkSyntax`. If so, no split needed. Otherwise, it scans for the last `)` that completes a valid `[...](...)` pattern with trailing text after it.
+
+### Guards & Edge Cases
+
+**IME composition guard:** Same as `inline_source` — track `compositionstart`/`compositionend`, skip all enter/leave transitions while composing.
+
+**`suppressEnter` flag:** Same pattern as `inline_source` — set `true` when `docChanged` is detected in `appendTransaction`, reset to `false` on navigation keys (`ArrowLeft`, `ArrowRight`, `ArrowUp`, `ArrowDown`, `Home`, `End`, `PageUp`, `PageDown`) via `handleKeyDown` and on `mousedown` via `handleDOMEvents`. While `true`, skip enter transitions for selection-only changes. Prevents source mode flashing after input rules fire.
+
+**`handleTextInput` bypass:** Inside `link_source`, dispatch text insertion directly to prevent Milkdown input rules from firing.
+
+**Backspace at node start:** Exit source mode first (restore link mark), then let the backspace proceed normally. Prevents raw syntax leaking into adjacent content.
+
+**Undo/redo:** Enter/leave use `addToHistory: false`. Text edits within `link_source` go into history normally. Undo restoring invalid syntax degrades gracefully to plain text on leave.
+
+### Decorations & Styling
+
+Inline decorations for visual distinction of structural characters, built by `makeDecorationPlugin`:
+
+| Region | CSS Class |
+|--------|-----------|
+| `[` | `.syntax-marker` |
+| text | (unstyled) |
+| `](` | `.syntax-marker` |
+| url | `.link-url` |
+| ` "title"` (if present) | `.link-url` |
+| `)` | `.syntax-marker` |
+
+```css
+.milkdown .editor .link-source {
+  font-family: inherit;
+  border-radius: 2px;
+  background: var(--crepe-color-inline-area, #f5f5f5);
+  caret-color: var(--crepe-color-on-background, #333);
+}
+
+.milkdown .editor .link-source .link-url {
+  opacity: 0.6;
+}
+```
+
+Reuses existing `.syntax-marker` styling (muted opacity).
+
+## Files
+
+New files:
+
+- `ui/plugins/link-source/syntax.ts` — `parseLinkSyntax`, `buildLinkRawText`, constants
+- `ui/plugins/link-source/node.ts` — `link_source` node schema via `$node()` with remark serializer
+- `ui/plugins/link-source/plugin.ts` — ProseMirror plugin: enter/leave state machine, Cmd+K handler, Cmd+click handler, decorations, IME guard, input rule bypass
+- `ui/plugins/link-source/index.ts` — barrel exports
+
+Modified files:
+
+- `ui/components/Editor.tsx` — register `link_source` plugins
+- `ui/plugins/inline-source/plugin.ts` — cross-node leave check (leave `link_source` when entering `inline_source` and vice versa)
+- `ui/theme/skriv.css` — `.link-source` and `.link-url` styles

--- a/ui/__tests__/plugins/link-source/node.test.ts
+++ b/ui/__tests__/plugins/link-source/node.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { linkSourceSerializerRunner } from "../../../plugins/link-source/node";
+
+function mockState() {
+  const calls: { method: string; args: unknown[] }[] = [];
+  return {
+    calls,
+    openNode(type: string, attrs?: Record<string, unknown>) {
+      calls.push({ method: "openNode", args: [type, attrs] });
+    },
+    closeNode() {
+      calls.push({ method: "closeNode", args: [] });
+    },
+    addNode(type: string, attrs?: Record<string, unknown>, value?: string) {
+      calls.push({ method: "addNode", args: [type, attrs, value] });
+    },
+  };
+}
+
+describe("linkSourceSerializerRunner", () => {
+  it("serializes valid link syntax from raw text", () => {
+    const state = mockState();
+    linkSourceSerializerRunner(
+      state as never,
+      {
+        textContent: "[hello](https://example.com)",
+        attrs: { href: "https://example.com", title: "" },
+      } as never
+    );
+    expect(state.calls).toEqual([
+      {
+        method: "openNode",
+        args: ["link", { url: "https://example.com", title: undefined }],
+      },
+      { method: "addNode", args: ["text", undefined, "hello"] },
+      { method: "closeNode", args: [] },
+    ]);
+  });
+
+  it("serializes link with title", () => {
+    const state = mockState();
+    linkSourceSerializerRunner(
+      state as never,
+      {
+        textContent: '[text](url "My Title")',
+        attrs: { href: "url", title: "My Title" },
+      } as never
+    );
+    expect(state.calls).toEqual([
+      {
+        method: "openNode",
+        args: ["link", { url: "https://url", title: "My Title" }],
+      },
+      { method: "addNode", args: ["text", undefined, "text"] },
+      { method: "closeNode", args: [] },
+    ]);
+  });
+
+  it("serializes link with inner bold marks", () => {
+    const state = mockState();
+    linkSourceSerializerRunner(
+      state as never,
+      {
+        textContent: "[**bold**](url)",
+        attrs: { href: "url", title: "" },
+      } as never
+    );
+    expect(state.calls).toEqual([
+      { method: "openNode", args: ["link", { url: "https://url", title: undefined }] },
+      { method: "openNode", args: ["strong", undefined] },
+      { method: "addNode", args: ["text", undefined, "bold"] },
+      { method: "closeNode", args: [] },
+      { method: "closeNode", args: [] },
+    ]);
+  });
+
+  it("falls back to attrs when raw text is invalid", () => {
+    const state = mockState();
+    linkSourceSerializerRunner(
+      state as never,
+      {
+        textContent: "[incomplete",
+        attrs: { href: "https://example.com", title: "" },
+      } as never
+    );
+    expect(state.calls).toEqual([
+      {
+        method: "openNode",
+        args: ["link", { url: "https://example.com", title: undefined }],
+      },
+      { method: "addNode", args: ["text", undefined, "[incomplete"] },
+      { method: "closeNode", args: [] },
+    ]);
+  });
+
+  it("serializes as plain text when no valid link data", () => {
+    const state = mockState();
+    linkSourceSerializerRunner(
+      state as never,
+      {
+        textContent: "just text",
+        attrs: { href: "", title: "" },
+      } as never
+    );
+    expect(state.calls).toEqual([{ method: "addNode", args: ["text", undefined, "just text"] }]);
+  });
+});

--- a/ui/__tests__/plugins/link-source/plugin.test.ts
+++ b/ui/__tests__/plugins/link-source/plugin.test.ts
@@ -1,0 +1,853 @@
+import { describe, it, expect } from "vitest";
+import { Schema } from "@milkdown/kit/prose/model";
+import { EditorState, TextSelection } from "@milkdown/kit/prose/state";
+import {
+  buildLinkDecorations,
+  findLinkSpan,
+  handleLinkSourceTransition,
+  leaveLinkSource,
+} from "../../../plugins/link-source/plugin";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*", group: "block" },
+    text: { inline: true },
+  },
+  marks: {
+    link: {
+      attrs: { href: { default: "" }, title: { default: null } },
+      toDOM: (mark) => ["a", { href: mark.attrs.href }] as const,
+    },
+    strong: { toDOM: () => ["strong"] as const },
+  },
+});
+
+function makeDoc(...children: ReturnType<typeof schema.text>[]) {
+  return schema.node("doc", null, [schema.node("paragraph", null, children)]);
+}
+
+describe("findLinkSpan", () => {
+  it("finds span for a simple link mark", () => {
+    const linkMark = schema.marks.link.create({ href: "https://example.com" });
+    const doc = makeDoc(
+      schema.text("before "),
+      schema.text("link text", [linkMark]),
+      schema.text(" after")
+    );
+    // doc open(1) + "before "(7) + 1 into link = 9
+    const pos = 1 + 7 + 1;
+    const span = findLinkSpan(doc, pos, schema.marks.link, "https://example.com");
+    expect(span).not.toBeNull();
+    expect(doc.textBetween(span!.from, span!.to)).toBe("link text");
+  });
+
+  it("respects href boundaries", () => {
+    const link1 = schema.marks.link.create({ href: "https://a.com" });
+    const link2 = schema.marks.link.create({ href: "https://b.com" });
+    const doc = makeDoc(schema.text("aaa", [link1]), schema.text("bbb", [link2]));
+    const span = findLinkSpan(doc, 2, schema.marks.link, "https://a.com");
+    expect(span).not.toBeNull();
+    expect(doc.textBetween(span!.from, span!.to)).toBe("aaa");
+  });
+
+  it("returns null when no link mark at position", () => {
+    const doc = makeDoc(schema.text("plain text"));
+    const span = findLinkSpan(doc, 3, schema.marks.link, "https://example.com");
+    expect(span).toBeNull();
+  });
+
+  it("spans multiple text nodes with same href", () => {
+    const linkMark = schema.marks.link.create({ href: "https://x.com" });
+    const doc = makeDoc(
+      schema.text("aaa", [linkMark]),
+      schema.text("bbb", [linkMark, schema.marks.strong.create()])
+    );
+    const span = findLinkSpan(doc, 2, schema.marks.link, "https://x.com");
+    expect(span).not.toBeNull();
+    expect(doc.textBetween(span!.from, span!.to)).toBe("aaabbb");
+  });
+
+  it("stops at href boundary when spanning forward", () => {
+    const link1 = schema.marks.link.create({ href: "https://a.com" });
+    const link2 = schema.marks.link.create({ href: "https://b.com" });
+    const doc = makeDoc(
+      schema.text("aaa", [link1]),
+      schema.text("bbb", [link1]),
+      schema.text("ccc", [link2])
+    );
+    const span = findLinkSpan(doc, 2, schema.marks.link, "https://a.com");
+    expect(span).not.toBeNull();
+    expect(doc.textBetween(span!.from, span!.to)).toBe("aaabbb");
+  });
+
+  it("finds span when cursor is at boundary (after link)", () => {
+    const linkMark = schema.marks.link.create({ href: "https://example.com" });
+    const doc = makeDoc(schema.text("link", [linkMark]), schema.text(" after"));
+    // Cursor at pos 5 = right at boundary between "link" and " after"
+    // The index at pos 5 points to " after", which has no link mark.
+    // But the previous child "link" does have the link mark, so findLinkSpan
+    // should find it via the fallback to the previous child.
+    const span = findLinkSpan(doc, 5, schema.marks.link, "https://example.com");
+    expect(span).not.toBeNull();
+    expect(doc.textBetween(span!.from, span!.to)).toBe("link");
+  });
+
+  it("returns null when href does not match", () => {
+    const linkMark = schema.marks.link.create({ href: "https://other.com" });
+    const doc = makeDoc(schema.text("link", [linkMark]));
+    const span = findLinkSpan(doc, 2, schema.marks.link, "https://example.com");
+    expect(span).toBeNull();
+  });
+});
+
+// Extended schema with link_source, inline_source, and marks for transition tests
+const transitionSchema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*" },
+    text: { group: "inline" },
+    link_source: {
+      group: "inline",
+      inline: true,
+      content: "text*",
+      marks: "",
+      attrs: { href: { default: "" }, title: { default: "" } },
+      toDOM: () => ["span", { class: "link-source" }, 0] as const,
+    },
+    inline_source: {
+      group: "inline",
+      inline: true,
+      content: "text*",
+      marks: "",
+      attrs: { syntax: { default: "" } },
+      toDOM: () => ["span", { class: "inline-source" }, 0] as const,
+    },
+  },
+  marks: {
+    link: {
+      attrs: { href: { default: "" }, title: { default: null } },
+      toDOM: (mark) => ["a", { href: mark.attrs.href }] as const,
+    },
+    strong: { toDOM: () => ["strong"] as const },
+    emphasis: { toDOM: () => ["em"] as const },
+  },
+});
+
+describe("leaveLinkSource", () => {
+  it("creates text node with link mark for valid link syntax", () => {
+    // doc: <p><link_source>[text](https://example.com)</link_source></p>
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "https://example.com", title: "" },
+          transitionSchema.text("[text](https://example.com)")
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    // link_source opens at pos 1, closes at 1 + nodeSize
+    // nodeSize = 1 (open) + 27 (text) + 1 (close) = 29
+    const nodeFrom = 1;
+    const nodeTo = 1 + doc.firstChild!.firstChild!.nodeSize;
+
+    const result = leaveLinkSource(
+      tr,
+      transitionSchema,
+      nodeFrom,
+      nodeTo,
+      "[text](https://example.com)",
+      "https://example.com",
+      ""
+    );
+
+    expect(result).toBe(true);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    let foundLink = false;
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        const linkMark = transitionSchema.marks.link.isInSet(node.marks);
+        if (linkMark) {
+          foundLink = true;
+          expect(node.text).toBe("text");
+          expect(linkMark.attrs.href).toBe("https://example.com");
+        }
+      }
+    });
+    expect(foundLink).toBe(true);
+  });
+
+  it("creates text node with link + strong marks for valid link with inner bold", () => {
+    const raw = "[**bold**](https://example.com)";
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "https://example.com", title: "" },
+          transitionSchema.text(raw)
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    const nodeFrom = 1;
+    const nodeTo = 1 + doc.firstChild!.firstChild!.nodeSize;
+
+    const result = leaveLinkSource(
+      tr,
+      transitionSchema,
+      nodeFrom,
+      nodeTo,
+      raw,
+      "https://example.com",
+      ""
+    );
+    expect(result).toBe(true);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    let foundBoldLink = false;
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        const linkMark = transitionSchema.marks.link.isInSet(node.marks);
+        const strongMark = transitionSchema.marks.strong.isInSet(node.marks);
+        if (linkMark && strongMark) {
+          foundBoldLink = true;
+          expect(node.text).toBe("bold");
+          expect(linkMark.attrs.href).toBe("https://example.com");
+        }
+      }
+    });
+    expect(foundBoldLink).toBe(true);
+  });
+
+  it("creates link mark with title attr for valid link with title", () => {
+    const raw = '[text](https://example.com "My Title")';
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "https://example.com", title: "My Title" },
+          transitionSchema.text(raw)
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    const nodeFrom = 1;
+    const nodeTo = 1 + doc.firstChild!.firstChild!.nodeSize;
+
+    const result = leaveLinkSource(
+      tr,
+      transitionSchema,
+      nodeFrom,
+      nodeTo,
+      raw,
+      "https://example.com",
+      "My Title"
+    );
+    expect(result).toBe(true);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    let foundLink = false;
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        const linkMark = transitionSchema.marks.link.isInSet(node.marks);
+        if (linkMark) {
+          foundLink = true;
+          expect(node.text).toBe("text");
+          expect(linkMark.attrs.href).toBe("https://example.com");
+          expect(linkMark.attrs.title).toBe("My Title");
+        }
+      }
+    });
+    expect(foundLink).toBe(true);
+  });
+
+  it("deletes the node range and returns false for empty raw text", () => {
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.text("hello "),
+        transitionSchema.nodes.link_source.create({ href: "https://example.com", title: "" }),
+        transitionSchema.text(" world"),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    // "hello " = pos 1-6, link_source opens at 7, closes at 8 (empty content)
+    const nodeFrom = 7;
+    const nodeTo = 7 + doc.firstChild!.child(1).nodeSize;
+
+    const result = leaveLinkSource(
+      tr,
+      transitionSchema,
+      nodeFrom,
+      nodeTo,
+      "",
+      "https://example.com",
+      ""
+    );
+    expect(result).toBe(false);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    let foundLinkSource = false;
+    paragraph.forEach((node) => {
+      if (node.type.name === "link_source") foundLinkSource = true;
+    });
+    expect(foundLinkSource).toBe(false);
+  });
+
+  it("creates text node with link mark from fallback attrs for invalid syntax with fallback href", () => {
+    const raw = "[incomplete";
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "https://example.com", title: "" },
+          transitionSchema.text(raw)
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    const nodeFrom = 1;
+    const nodeTo = 1 + doc.firstChild!.firstChild!.nodeSize;
+
+    const result = leaveLinkSource(
+      tr,
+      transitionSchema,
+      nodeFrom,
+      nodeTo,
+      raw,
+      "https://example.com",
+      ""
+    );
+    expect(result).toBe(true);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    let foundLink = false;
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        const linkMark = transitionSchema.marks.link.isInSet(node.marks);
+        if (linkMark) {
+          foundLink = true;
+          expect(node.text).toBe("[incomplete");
+          expect(linkMark.attrs.href).toBe("https://example.com");
+        }
+      }
+    });
+    expect(foundLink).toBe(true);
+  });
+
+  it("creates plain text node for invalid syntax without fallback href", () => {
+    const raw = "[incomplete";
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "", title: "" },
+          transitionSchema.text(raw)
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    const nodeFrom = 1;
+    const nodeTo = 1 + doc.firstChild!.firstChild!.nodeSize;
+
+    const result = leaveLinkSource(tr, transitionSchema, nodeFrom, nodeTo, raw, "", "");
+    expect(result).toBe(true);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        expect(node.text).toBe("[incomplete");
+        expect(node.marks.length).toBe(0);
+      }
+    });
+  });
+
+  it("creates plain text for incomplete syntax like just opening bracket with text", () => {
+    const raw = "[text";
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "", title: "" },
+          transitionSchema.text(raw)
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const tr = state.tr;
+
+    const nodeFrom = 1;
+    const nodeTo = 1 + doc.firstChild!.firstChild!.nodeSize;
+
+    const result = leaveLinkSource(tr, transitionSchema, nodeFrom, nodeTo, raw, "", "");
+    expect(result).toBe(true);
+
+    const newDoc = state.apply(tr).doc;
+    const paragraph = newDoc.firstChild!;
+    expect(paragraph.textContent).toBe("[text");
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        expect(node.marks.length).toBe(0);
+      }
+    });
+  });
+});
+
+describe("handleLinkSourceTransition", () => {
+  describe("enter transition", () => {
+    it("replaces link mark with link_source node when cursor enters a link", () => {
+      const linkMark = transitionSchema.marks.link.create({ href: "https://example.com" });
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("hello "),
+          transitionSchema.text("link text", [linkMark]),
+          transitionSchema.text(" world"),
+        ]),
+      ]);
+
+      // Start cursor outside the link
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 3), // in "hello"
+      });
+
+      // Move cursor into the link span
+      // "hello " = pos 1-6, "link text" = pos 7-15
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 10));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).not.toBeNull();
+
+      if (result) {
+        const resultState = newState.apply(result);
+        const paragraph = resultState.doc.firstChild!;
+        let foundLinkSource = false;
+        paragraph.forEach((node) => {
+          if (node.type.name === "link_source") {
+            foundLinkSource = true;
+            expect(node.textContent).toBe("[link text](https://example.com)");
+            expect(node.attrs.href).toBe("https://example.com");
+          }
+        });
+        expect(foundLinkSource).toBe(true);
+      }
+    });
+
+    it("returns null when cursor is not near any link mark", () => {
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [transitionSchema.text("hello world")]),
+      ]);
+
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 3),
+      });
+
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 5));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for range selection on link", () => {
+      const linkMark = transitionSchema.marks.link.create({ href: "https://example.com" });
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("hello "),
+          transitionSchema.text("link text", [linkMark]),
+          transitionSchema.text(" world"),
+        ]),
+      ]);
+
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 3),
+      });
+
+      // Create a range selection across the link
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 7, 16));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when doc changed", () => {
+      const linkMark = transitionSchema.marks.link.create({ href: "https://example.com" });
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("hello "),
+          transitionSchema.text("link text", [linkMark]),
+        ]),
+      ]);
+
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 3),
+      });
+
+      // Insert text (doc change) and move cursor near link
+      const tr = oldState.tr.insertText("X", 3);
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).toBeNull();
+    });
+
+    it("includes inner bold marks in raw text for bold link", () => {
+      const linkMark = transitionSchema.marks.link.create({ href: "https://example.com" });
+      const strongMark = transitionSchema.marks.strong.create();
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("bold", [linkMark, strongMark]),
+        ]),
+      ]);
+
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 1),
+      });
+
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 3));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).not.toBeNull();
+
+      if (result) {
+        const resultState = newState.apply(result);
+        const paragraph = resultState.doc.firstChild!;
+        let foundLinkSource = false;
+        paragraph.forEach((node) => {
+          if (node.type.name === "link_source") {
+            foundLinkSource = true;
+            expect(node.textContent).toBe("[**bold**](https://example.com)");
+          }
+        });
+        expect(foundLinkSource).toBe(true);
+      }
+    });
+  });
+
+  describe("leave transition", () => {
+    it("replaces link_source with link-marked text when cursor leaves", () => {
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("hello "),
+          transitionSchema.nodes.link_source.create(
+            { href: "https://example.com", title: "" },
+            transitionSchema.text("[text](https://example.com)")
+          ),
+          transitionSchema.text(" world"),
+        ]),
+      ]);
+
+      // "hello " = pos 1-6, link_source opens at 7, content starts at 8
+      // "[text](https://example.com)" = 27 chars at pos 8-34
+      // link_source closes at 35, " world" starts at 35
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 12), // inside link_source
+      });
+
+      // Move cursor to " world" area
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 38));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).not.toBeNull();
+
+      if (result) {
+        const resultState = newState.apply(result);
+        const paragraph = resultState.doc.firstChild!;
+
+        let foundLinkSource = false;
+        let foundLink = false;
+        paragraph.forEach((node) => {
+          if (node.type.name === "link_source") foundLinkSource = true;
+          if (node.isText) {
+            const lm = transitionSchema.marks.link.isInSet(node.marks);
+            if (lm) {
+              foundLink = true;
+              expect(node.text).toBe("text");
+              expect(lm.attrs.href).toBe("https://example.com");
+            }
+          }
+        });
+        expect(foundLinkSource).toBe(false);
+        expect(foundLink).toBe(true);
+      }
+    });
+
+    it("converts link_source with incomplete syntax to plain text on leave", () => {
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("before "),
+          transitionSchema.nodes.link_source.create(
+            { href: "", title: "" },
+            transitionSchema.text("[text")
+          ),
+        ]),
+      ]);
+
+      // "before " = pos 1-7, link_source opens at 8, content starts at 9
+      // "[text" = 5 chars at pos 9-13, link_source closes at 14
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 11), // inside link_source
+      });
+
+      // Move cursor to "before" area
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 3));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).not.toBeNull();
+
+      if (result) {
+        const resultState = newState.apply(result);
+        const paragraph = resultState.doc.firstChild!;
+        expect(paragraph.textContent).toBe("before [text");
+        paragraph.forEach((node) => {
+          if (node.isText) {
+            expect(node.marks.length).toBe(0);
+          }
+        });
+      }
+    });
+
+    it("deletes empty link_source on leave", () => {
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.text("hello "),
+          transitionSchema.nodes.link_source.create({ href: "https://example.com", title: "" }),
+          transitionSchema.text(" world"),
+        ]),
+      ]);
+
+      // "hello " = pos 1-6, link_source opens at 7, closes at 8 (empty)
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 8), // at link_source boundary
+      });
+
+      // Move cursor to "hello" area
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 3));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).not.toBeNull();
+
+      if (result) {
+        const resultState = newState.apply(result);
+        const paragraph = resultState.doc.firstChild!;
+        let foundLinkSource = false;
+        paragraph.forEach((node) => {
+          if (node.type.name === "link_source") foundLinkSource = true;
+        });
+        expect(foundLinkSource).toBe(false);
+      }
+    });
+  });
+
+  describe("trailing split", () => {
+    it("splits link_source containing trailing text after valid link", () => {
+      // link_source contains "[text](url) extra" — cursor inside
+      const doc = transitionSchema.node("doc", null, [
+        transitionSchema.node("paragraph", null, [
+          transitionSchema.nodes.link_source.create(
+            { href: "url", title: "" },
+            transitionSchema.text("[text](url) extra")
+          ),
+        ]),
+      ]);
+
+      // link_source opens at 1, content starts at 2
+      // "[text](url) extra" = 17 chars at pos 2-18, link_source closes at 19
+      // Cursor inside the link_source content
+      const oldState = EditorState.create({
+        doc,
+        schema: transitionSchema,
+        selection: TextSelection.create(doc, 18), // near end of content
+      });
+
+      // Simulate cursor still inside (but different position to trigger)
+      const tr = oldState.tr.setSelection(TextSelection.create(doc, 19));
+      const newState = oldState.apply(tr);
+
+      const result = handleLinkSourceTransition([tr], oldState, newState);
+      expect(result).not.toBeNull();
+
+      if (result) {
+        const resultState = newState.apply(result);
+        const paragraph = resultState.doc.firstChild!;
+
+        // link_source should be gone
+        let foundLinkSource = false;
+        paragraph.forEach((node) => {
+          if (node.type.name === "link_source") foundLinkSource = true;
+        });
+        expect(foundLinkSource).toBe(false);
+
+        // Should have "text" with link mark
+        let foundLink = false;
+        paragraph.forEach((node) => {
+          if (node.isText) {
+            const lm = transitionSchema.marks.link.isInSet(node.marks);
+            if (lm) {
+              foundLink = true;
+              expect(node.text).toBe("text");
+              expect(lm.attrs.href).toBe("https://url");
+            }
+          }
+        });
+        expect(foundLink).toBe(true);
+
+        // Total text content should include trailing " extra"
+        expect(paragraph.textContent).toBe("text extra");
+      }
+    });
+  });
+});
+
+describe("buildLinkDecorations", () => {
+  it("produces 4 decorations for simple [text](url)", () => {
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "https://example.com", title: "" },
+          transitionSchema.text("[text](https://example.com)")
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const decoSet = buildLinkDecorations(state);
+    const decos = decoSet.find();
+
+    expect(decos).toHaveLength(4);
+
+    // Content starts at pos 2 (doc open + paragraph open + link_source open = 1+0+1=2)
+    // Actually: doc has no open token in position counting, paragraph opens at 0, content at 1.
+    // link_source opens at 1, content starts at 2.
+    // "[text](https://example.com)" = 27 chars
+    // "[" at pos 2-3
+    // "](" at pos 2+6=8 to 10 (closeBracket = 6 in raw, so contentStart + 6 = 8, 8 to 10)
+    // Wait: raw = "[text](https://example.com)", closeBracket = raw.indexOf("](") = 5
+    // "[" decoration: contentStart to contentStart+1 = 2 to 3
+    // "](" decoration: contentStart+5 to contentStart+7 = 7 to 9
+    // URL decoration: contentStart+7 to contentEnd-1 = 9 to 28
+    // Wait, let me recalculate. contentStart = pos + 1 = 1 + 1 = 2
+    // contentEnd = pos + nodeSize - 1 = 1 + 29 - 1 = 29
+    // raw.length = 27, closeBracket = 5
+    // "[" : 2 to 3
+    // "](" : 2+5=7 to 2+5+2=9
+    // URL: 9 to 28 (contentEnd - 1 = 29 - 1 = 28)
+    // ")" : 28 to 29
+
+    // Verify decoration classes
+    const classes = decos.map(
+      (d) => (d as unknown as { type: { attrs: { class: string } } }).type.attrs.class
+    );
+    expect(classes).toEqual(["syntax-marker", "syntax-marker", "link-url", "syntax-marker"]);
+  });
+
+  it("returns empty DecorationSet when no link_source nodes exist", () => {
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [transitionSchema.text("hello world")]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const decoSet = buildLinkDecorations(state);
+    const decos = decoSet.find();
+
+    expect(decos).toHaveLength(0);
+  });
+
+  it("produces no decorations for partial raw text without ](", () => {
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "", title: "" },
+          transitionSchema.text("[text")
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const decoSet = buildLinkDecorations(state);
+    const decos = decoSet.find();
+
+    expect(decos).toHaveLength(0);
+  });
+
+  it("produces no decorations for raw text missing opening bracket", () => {
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "", title: "" },
+          transitionSchema.text("text](url)")
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const decoSet = buildLinkDecorations(state);
+    const decos = decoSet.find();
+
+    expect(decos).toHaveLength(0);
+  });
+
+  it("marks correct positions for decorations", () => {
+    const doc = transitionSchema.node("doc", null, [
+      transitionSchema.node("paragraph", null, [
+        transitionSchema.nodes.link_source.create(
+          { href: "url", title: "" },
+          transitionSchema.text("[hi](url)")
+        ),
+      ]),
+    ]);
+    const state = EditorState.create({ doc, schema: transitionSchema });
+    const decoSet = buildLinkDecorations(state);
+    const decos = decoSet.find();
+
+    expect(decos).toHaveLength(4);
+
+    // link_source at pos 1, content starts at 2
+    // raw = "[hi](url)", closeBracket = 3
+    // "[" : 2 to 3
+    expect(decos[0]!.from).toBe(2);
+    expect(decos[0]!.to).toBe(3);
+
+    // "](" : 2+3=5 to 2+3+2=7
+    expect(decos[1]!.from).toBe(5);
+    expect(decos[1]!.to).toBe(7);
+
+    // "url" : 7 to 10 (contentEnd - 1 = 1 + 11 - 1 - 1 = 10)
+    expect(decos[2]!.from).toBe(7);
+    expect(decos[2]!.to).toBe(10);
+
+    // ")" : 10 to 11 (contentEnd = 1 + 11 - 1 = 11)
+    expect(decos[3]!.from).toBe(10);
+    expect(decos[3]!.to).toBe(11);
+  });
+});

--- a/ui/__tests__/plugins/link-source/syntax.test.ts
+++ b/ui/__tests__/plugins/link-source/syntax.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseLinkSyntax,
+  buildLinkRawText,
+  findLinkTrailingSplit,
+  normalizeHref,
+  LINK_INPUT_RULE_REGEX,
+} from "../../../plugins/link-source/syntax";
+
+describe("parseLinkSyntax", () => {
+  it("parses a simple link", () => {
+    expect(parseLinkSyntax("[text](https://example.com)")).toEqual({
+      text: "text",
+      href: "https://example.com",
+      title: "",
+    });
+  });
+  it("parses a link with title", () => {
+    expect(parseLinkSyntax('[text](url "My Title")')).toEqual({
+      text: "text",
+      href: "https://url",
+      title: "My Title",
+    });
+  });
+  it("preserves inner mark syntax in text", () => {
+    expect(parseLinkSyntax("[**bold**](url)")).toEqual({
+      text: "**bold**",
+      href: "https://url",
+      title: "",
+    });
+  });
+  it("returns null for empty string", () => {
+    expect(parseLinkSyntax("")).toBeNull();
+  });
+  it("returns null for incomplete syntax — missing closing paren", () => {
+    expect(parseLinkSyntax("[text](url")).toBeNull();
+  });
+  it("returns null for incomplete syntax — missing opening bracket", () => {
+    expect(parseLinkSyntax("text](url)")).toBeNull();
+  });
+  it("returns null for empty text", () => {
+    expect(parseLinkSyntax("[](url)")).toBeNull();
+  });
+  it("returns null for empty url", () => {
+    expect(parseLinkSyntax("[text]()")).toBeNull();
+  });
+  it("returns null for plain text", () => {
+    expect(parseLinkSyntax("just plain text")).toBeNull();
+  });
+  it("returns null for just brackets", () => {
+    expect(parseLinkSyntax("[]()")).toBeNull();
+  });
+  it("handles urls with special characters", () => {
+    expect(parseLinkSyntax("[text](https://example.com/path?q=1&r=2#anchor)")).toEqual({
+      text: "text",
+      href: "https://example.com/path?q=1&r=2#anchor",
+      title: "",
+    });
+  });
+  it("handles text with spaces", () => {
+    expect(parseLinkSyntax("[click here](url)")).toEqual({
+      text: "click here",
+      href: "https://url",
+      title: "",
+    });
+  });
+  it("normalizes bare domain to https", () => {
+    expect(parseLinkSyntax("[text](example.com)")).toEqual({
+      text: "text",
+      href: "https://example.com",
+      title: "",
+    });
+  });
+  it("preserves existing https protocol", () => {
+    expect(parseLinkSyntax("[text](https://example.com)")!.href).toBe("https://example.com");
+  });
+  it("preserves existing http protocol", () => {
+    expect(parseLinkSyntax("[text](http://example.com)")!.href).toBe("http://example.com");
+  });
+  it("preserves mailto protocol", () => {
+    expect(parseLinkSyntax("[text](mailto:user@example.com)")!.href).toBe(
+      "mailto:user@example.com"
+    );
+  });
+  it("preserves anchor links", () => {
+    expect(parseLinkSyntax("[text](#section)")!.href).toBe("#section");
+  });
+  it("preserves relative paths", () => {
+    expect(parseLinkSyntax("[text](/path/to/page)")!.href).toBe("/path/to/page");
+  });
+});
+
+describe("buildLinkRawText", () => {
+  it("builds simple link syntax", () => {
+    expect(buildLinkRawText("text", "https://example.com")).toBe("[text](https://example.com)");
+  });
+  it("builds link syntax with title", () => {
+    expect(buildLinkRawText("text", "url", "My Title")).toBe('[text](url "My Title")');
+  });
+  it("builds link syntax without title when empty", () => {
+    expect(buildLinkRawText("text", "url", "")).toBe("[text](url)");
+  });
+  it("builds link syntax without title when undefined", () => {
+    expect(buildLinkRawText("text", "url")).toBe("[text](url)");
+  });
+});
+
+describe("LINK_INPUT_RULE_REGEX", () => {
+  it("matches simple link syntax", () => {
+    const match = "[text](url)".match(LINK_INPUT_RULE_REGEX);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("text");
+    expect(match![2]).toBe("url");
+  });
+  it("matches link with long URL", () => {
+    const match = "[click here](https://example.com/path?q=1)".match(LINK_INPUT_RULE_REGEX);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("click here");
+    expect(match![2]).toBe("https://example.com/path?q=1");
+  });
+  it("does not match empty text", () => {
+    expect("[](url)".match(LINK_INPUT_RULE_REGEX)).toBeNull();
+  });
+  it("does not match empty url", () => {
+    expect("[text]()".match(LINK_INPUT_RULE_REGEX)).toBeNull();
+  });
+  it("does not greedily match across multiple links", () => {
+    const match = "[foo](bar) and [baz](qux)".match(LINK_INPUT_RULE_REGEX);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("baz");
+    expect(match![2]).toBe("qux");
+  });
+});
+
+describe("normalizeHref", () => {
+  it("prepends https:// to bare domains", () => {
+    expect(normalizeHref("example.com")).toBe("https://example.com");
+  });
+  it("prepends https:// to domain with path", () => {
+    expect(normalizeHref("example.com/path")).toBe("https://example.com/path");
+  });
+  it("preserves https://", () => {
+    expect(normalizeHref("https://example.com")).toBe("https://example.com");
+  });
+  it("preserves http://", () => {
+    expect(normalizeHref("http://example.com")).toBe("http://example.com");
+  });
+  it("preserves mailto:", () => {
+    expect(normalizeHref("mailto:user@example.com")).toBe("mailto:user@example.com");
+  });
+  it("preserves ftp://", () => {
+    expect(normalizeHref("ftp://files.example.com")).toBe("ftp://files.example.com");
+  });
+  it("preserves anchor links", () => {
+    expect(normalizeHref("#section")).toBe("#section");
+  });
+  it("preserves relative paths", () => {
+    expect(normalizeHref("/path/to/page")).toBe("/path/to/page");
+  });
+  it("returns empty string unchanged", () => {
+    expect(normalizeHref("")).toBe("");
+  });
+});
+
+describe("findLinkTrailingSplit", () => {
+  it("returns null for empty string", () => {
+    expect(findLinkTrailingSplit("")).toBeNull();
+  });
+  it("returns null for complete link syntax (no trailing)", () => {
+    expect(findLinkTrailingSplit("[text](url)")).toBeNull();
+  });
+  it("returns null for plain text", () => {
+    expect(findLinkTrailingSplit("just text")).toBeNull();
+  });
+  it("returns null for incomplete syntax", () => {
+    expect(findLinkTrailingSplit("[text](url")).toBeNull();
+  });
+  it("splits link with trailing space", () => {
+    expect(findLinkTrailingSplit("[text](url) ")).toEqual({
+      text: "text",
+      href: "https://url",
+      title: "",
+      trailing: " ",
+    });
+  });
+  it("splits link with trailing text", () => {
+    expect(findLinkTrailingSplit("[text](url) and more")).toEqual({
+      text: "text",
+      href: "https://url",
+      title: "",
+      trailing: " and more",
+    });
+  });
+  it("splits link with trailing character", () => {
+    expect(findLinkTrailingSplit("[text](url)x")).toEqual({
+      text: "text",
+      href: "https://url",
+      title: "",
+      trailing: "x",
+    });
+  });
+  it("splits link with title and trailing text", () => {
+    expect(findLinkTrailingSplit('[text](url "title") more')).toEqual({
+      text: "text",
+      href: "https://url",
+      title: "title",
+      trailing: " more",
+    });
+  });
+});

--- a/ui/components/Editor.tsx
+++ b/ui/components/Editor.tsx
@@ -8,6 +8,7 @@ import { inlineSourceNode, inlineSourcePlugin } from "../plugins/inline-source";
 import { headingSourceNode, headingSourcePlugin } from "../plugins/heading-source";
 import { listSourceView, listCursorPlugin } from "../plugins/list-source";
 import { codeBlockSourcePlugin } from "../plugins/code-block-source";
+import { linkSourceNode, linkSourcePlugin } from "../plugins/link-source";
 import { mermaidBlockNode, mermaidBlockView, remarkMermaidPlugin } from "../plugins/mermaid-block";
 import "@milkdown/crepe/theme/common/style.css";
 import "../theme/skriv.css";
@@ -56,7 +57,9 @@ const CrepeEditor = forwardRef<EditorHandle, EditorProps>(
             .use(headingSourcePlugin)
             .use(listSourceView)
             .use(listCursorPlugin)
-            .use(codeBlockSourcePlugin);
+            .use(codeBlockSourcePlugin)
+            .use(linkSourceNode)
+            .use(linkSourcePlugin);
         }
 
         crepe.editor.use(remarkMermaidPlugin).use(mermaidBlockNode).use(mermaidBlockView);

--- a/ui/plugins/inline-source/plugin.ts
+++ b/ui/plugins/inline-source/plugin.ts
@@ -1,5 +1,5 @@
 import { $prose } from "@milkdown/utils";
-import type { Node, Mark, MarkType } from "@milkdown/kit/prose/model";
+import type { Node, MarkType } from "@milkdown/kit/prose/model";
 import {
   EditorState,
   Plugin,
@@ -11,6 +11,8 @@ import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
 import type { EditorView } from "@milkdown/kit/prose/view";
 import { findFirstNodeOfType } from "../block-source/cursor";
 import { makeDecorationPlugin } from "../block-source/decoration";
+import { leaveLinkSource } from "../link-source/plugin";
+import { createMarks, NAV_KEYS } from "../shared/marks";
 import {
   buildRawText,
   computePrefixLength,
@@ -20,11 +22,6 @@ import {
   parseInlineSyntax,
   SUPPORTED_MARKS,
 } from "./syntax";
-
-/** Build Mark[] from mark names, filtering any that don't exist in the schema. */
-function createMarks(schema: { marks: Record<string, MarkType> }, markNames: string[]): Mark[] {
-  return markNames.map((name) => schema.marks[name]?.create()).filter((m): m is Mark => m != null);
-}
 
 /**
  * Replace an inline_source node with its parsed marked text (or plain
@@ -194,6 +191,14 @@ export function handleInlineSourceTransition(
   const marksBefore = nodeBefore?.marks ?? [];
   const marksAfter = nodeAfter?.marks ?? [];
 
+  // Yield to link-source when cursor is on a link mark
+  const linkMarkType = schema.marks.link;
+  if (linkMarkType) {
+    const hasLinkBefore = linkMarkType.isInSet(marksBefore);
+    const hasLinkAfter = linkMarkType.isInSet(marksAfter);
+    if (hasLinkBefore || hasLinkAfter) return null;
+  }
+
   // Find a supported mark at cursor position (left-biased)
   let targetMarkType = null;
   for (const markName of SUPPORTED_MARKS) {
@@ -212,9 +217,6 @@ export function handleInlineSourceTransition(
   if (!span) return null;
 
   // Collect supported mark names from the first text node in the span.
-  // v1 only handles same-boundary marks (all marks share start/end positions),
-  // so inspecting the first child is sufficient. Overlapping marks with different
-  // boundaries are out of scope — see design doc for future phases.
   const $spanStart = newState.doc.resolve(span.from);
   const firstChild = $spanStart.nodeAfter;
   if (!firstChild) return null;
@@ -225,8 +227,29 @@ export function handleInlineSourceTransition(
 
   if (markNames.length === 0) return null;
 
+  // Leave any existing link_source in the same transaction as enter,
+  // then remap positions through the mapping.
+  const tr = newState.tr;
+  let adjustedFrom = span.from;
+  let adjustedTo = span.to;
+
+  const linkSourceFound = findFirstNodeOfType(newState.doc, "link_source");
+  if (linkSourceFound) {
+    leaveLinkSource(
+      tr,
+      schema,
+      linkSourceFound.pos,
+      linkSourceFound.pos + linkSourceFound.node.nodeSize,
+      linkSourceFound.node.textContent,
+      linkSourceFound.node.attrs.href as string,
+      linkSourceFound.node.attrs.title as string
+    );
+    adjustedFrom = tr.mapping.map(span.from);
+    adjustedTo = tr.mapping.map(span.to);
+  }
+
   // Build raw text with syntax markers
-  const textContent = newState.doc.textBetween(span.from, span.to);
+  const textContent = tr.doc.textBetween(adjustedFrom, adjustedTo);
   const rawText = buildRawText(textContent, markNames);
 
   // Create inline_source node
@@ -235,9 +258,7 @@ export function handleInlineSourceTransition(
     schema.text(rawText)
   );
 
-  // Build transaction (non-historical — presentation change only)
-  const tr = newState.tr;
-  tr.replaceWith(span.from, span.to, inlineSource);
+  tr.replaceWith(adjustedFrom, adjustedTo, inlineSource);
   tr.setMeta("addToHistory", false);
 
   // Map cursor position: offset in rendered text -> offset in raw text
@@ -245,8 +266,7 @@ export function handleInlineSourceTransition(
   const offsetInSpan = $cursor.pos - span.from;
   const offsetInRaw = offsetInSpan + prefixLength;
 
-  // inline_source node content starts at span.from + 1 (after node open)
-  const contentStart = span.from + 1;
+  const contentStart = adjustedFrom + 1;
   const newCursorPos = Math.min(contentStart + offsetInRaw, contentStart + rawText.length);
   tr.setSelection(TextSelection.create(tr.doc, newCursorPos));
 
@@ -359,18 +379,6 @@ const inlineSourceDecoPlugin = $prose((_ctx) =>
 );
 
 const inlineSourceBehaviorKey = new PluginKey("inline-source-behavior");
-
-/** Keys that represent intentional cursor navigation. */
-const NAV_KEYS = new Set([
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowUp",
-  "ArrowDown",
-  "Home",
-  "End",
-  "PageUp",
-  "PageDown",
-]);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const inlineSourceBehaviorPlugin = $prose((_ctx) => {

--- a/ui/plugins/link-source/index.ts
+++ b/ui/plugins/link-source/index.ts
@@ -1,0 +1,3 @@
+export { linkSourceNode } from "./node";
+export { linkSourcePlugin, leaveLinkSource } from "./plugin";
+export { parseLinkSyntax, buildLinkRawText, normalizeHref, LINK_INPUT_RULE_REGEX } from "./syntax";

--- a/ui/plugins/link-source/node.ts
+++ b/ui/plugins/link-source/node.ts
@@ -1,0 +1,83 @@
+import { $node } from "@milkdown/utils";
+import { parseLinkSyntax } from "./syntax";
+import { MARK_SYNTAX, parseInlineSyntax } from "../inline-source/syntax";
+
+interface SerializerState {
+  openNode(type: string, attrs?: Record<string, unknown>): void;
+  closeNode(): void;
+  addNode(type: string, attrs?: Record<string, unknown>, value?: string): void;
+}
+
+interface SerializerNode {
+  textContent: string;
+  attrs: { href: string; title: string };
+}
+
+function serializeInlineText(state: SerializerState, text: string): void {
+  const parsed = parseInlineSyntax(text);
+  if (parsed.marks.length > 0) {
+    if (parsed.marks.length === 1 && parsed.marks[0] === "inlineCode") {
+      state.addNode("inlineCode", undefined, parsed.text);
+    } else {
+      for (const markName of parsed.marks) {
+        const remarkType = MARK_SYNTAX[markName]?.remarkType ?? markName;
+        state.openNode(remarkType);
+      }
+      state.addNode("text", undefined, parsed.text);
+      for (let i = parsed.marks.length - 1; i >= 0; i--) {
+        state.closeNode();
+      }
+    }
+  } else {
+    state.addNode("text", undefined, text);
+  }
+}
+
+export function linkSourceSerializerRunner(state: SerializerState, node: SerializerNode): void {
+  const raw = node.textContent;
+  const parsed = parseLinkSyntax(raw);
+
+  if (parsed) {
+    // Branch 1: raw text parses as valid link syntax
+    state.openNode("link", {
+      url: parsed.href,
+      title: parsed.title || undefined,
+    });
+    serializeInlineText(state, parsed.text);
+    state.closeNode();
+  } else if (node.attrs.href) {
+    // Branch 2: invalid syntax but has href attr as fallback
+    state.openNode("link", {
+      url: node.attrs.href,
+      title: node.attrs.title || undefined,
+    });
+    state.addNode("text", undefined, raw);
+    state.closeNode();
+  } else {
+    // Branch 3: no valid link data — serialize as plain text
+    state.addNode("text", undefined, raw);
+  }
+}
+
+export const linkSourceNode = $node("link_source", () => ({
+  group: "inline",
+  inline: true,
+  content: "text*",
+  marks: "",
+  attrs: {
+    href: { default: "" },
+    title: { default: "" },
+  },
+  toDOM: () => ["span", { class: "link-source" }, 0] as const,
+  parseDOM: [],
+  parseMarkdown: {
+    match: () => false,
+    runner: () => {},
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === "link_source",
+    runner: (state, node) => {
+      linkSourceSerializerRunner(state as never, node as never);
+    },
+  },
+}));

--- a/ui/plugins/link-source/plugin.ts
+++ b/ui/plugins/link-source/plugin.ts
@@ -1,0 +1,691 @@
+import { $prose } from "@milkdown/utils";
+import type { Node, Mark, MarkType } from "@milkdown/kit/prose/model";
+import { createMarks, NAV_KEYS } from "../shared/marks";
+import {
+  EditorState,
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type Transaction,
+} from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { inputRules, InputRule } from "@milkdown/kit/prose/inputrules";
+import { findFirstNodeOfType } from "../block-source/cursor";
+import { makeDecorationPlugin } from "../block-source/decoration";
+import { leaveInlineSource } from "../inline-source/plugin";
+import {
+  buildRawText,
+  parseInlineSyntax,
+  SUPPORTED_MARKS,
+  computePrefixLength,
+} from "../inline-source/syntax";
+import {
+  buildLinkRawText,
+  findLinkTrailingSplit,
+  LINK_INPUT_RULE_REGEX,
+  normalizeHref,
+  parseLinkSyntax,
+} from "./syntax";
+
+/** Create a text node with a link mark and optional inner marks from raw link text. */
+function createLinkTextNode(
+  schema: EditorState["schema"],
+  linkText: string,
+  href: string
+): { node: Node; linkMarkType: MarkType } | null {
+  const linkMarkType = schema.marks.link;
+  if (!linkMarkType) return null;
+  const innerParsed = parseInlineSyntax(linkText);
+  const linkMark = linkMarkType.create({ href, title: null });
+  const marks: Mark[] = [linkMark];
+  if (innerParsed.marks.length > 0) {
+    marks.push(...createMarks(schema, innerParsed.marks));
+  }
+  const displayText = innerParsed.marks.length > 0 ? innerParsed.text : linkText;
+  return { node: schema.text(displayText, marks), linkMarkType };
+}
+
+/**
+ * Find the extent of a link mark span at `pos`, matching by `targetHref`.
+ * Two adjacent link marks with different `href` values are separate spans.
+ */
+export function findLinkSpan(
+  doc: Node,
+  pos: number,
+  linkMarkType: MarkType,
+  targetHref: string
+): { from: number; to: number } | null {
+  const $pos = doc.resolve(pos);
+  const parent = $pos.parent;
+
+  if (!parent.isTextblock) return null;
+
+  const parentStart = $pos.start();
+  const index = $pos.index();
+
+  // Find the child at or near the cursor that has the link mark with matching href
+  let targetIndex = index;
+  if (targetIndex >= parent.childCount) {
+    targetIndex = parent.childCount - 1;
+  }
+  if (targetIndex < 0) return null;
+
+  function hasMatchingLink(node: Node): boolean {
+    const linkMark = linkMarkType.isInSet(node.marks);
+    return linkMark != null && linkMark.attrs.href === targetHref;
+  }
+
+  const child = parent.child(targetIndex);
+  if (!hasMatchingLink(child)) {
+    // Check previous child (cursor might be at boundary)
+    if (targetIndex > 0) {
+      const prevChild = parent.child(targetIndex - 1);
+      if (hasMatchingLink(prevChild)) {
+        targetIndex = targetIndex - 1;
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+
+  // Walk backward from targetIndex to find start
+  let from = parentStart;
+  for (let i = 0; i < targetIndex; i++) {
+    from += parent.child(i).nodeSize;
+  }
+  for (let i = targetIndex - 1; i >= 0; i--) {
+    const c = parent.child(i);
+    if (!hasMatchingLink(c)) break;
+    from -= c.nodeSize;
+  }
+
+  // Walk forward from targetIndex to find end
+  let to = parentStart;
+  for (let i = 0; i <= targetIndex; i++) {
+    to += parent.child(i).nodeSize;
+  }
+  for (let i = targetIndex + 1; i < parent.childCount; i++) {
+    const c = parent.child(i);
+    if (!hasMatchingLink(c)) break;
+    to += c.nodeSize;
+  }
+
+  return { from, to };
+}
+
+/**
+ * Replace a `link_source` node with parsed content. Exported for cross-plugin use.
+ *
+ * - If raw text parses as valid link -> create text node with `link` mark (and inner marks via `parseInlineSyntax`)
+ * - If raw text is invalid but fallbackHref exists -> create text with link mark from fallback attrs
+ * - If empty -> delete the node
+ * - Otherwise -> plain text
+ *
+ * Returns false if the node was empty and was deleted instead.
+ */
+export function leaveLinkSource(
+  tr: Transaction,
+  schema: EditorState["schema"],
+  nodeFrom: number,
+  nodeTo: number,
+  raw: string,
+  fallbackHref: string,
+  fallbackTitle: string
+): boolean {
+  if (!raw) {
+    tr.delete(nodeFrom, nodeTo);
+    return false;
+  }
+
+  const parsed = parseLinkSyntax(raw);
+  if (parsed) {
+    // Valid link syntax: create text with link mark (and inner marks)
+    const linkMark = schema.marks.link.create({
+      href: parsed.href,
+      title: parsed.title || null,
+    });
+    const innerParsed = parseInlineSyntax(parsed.text);
+    const marks: Mark[] = [linkMark];
+    if (innerParsed.marks.length > 0) {
+      marks.push(...createMarks(schema, innerParsed.marks));
+    }
+    const textContent = innerParsed.marks.length > 0 ? innerParsed.text : parsed.text;
+    tr.replaceWith(nodeFrom, nodeTo, schema.text(textContent, marks));
+  } else if (fallbackHref && !raw.includes("](")) {
+    // Truly broken syntax (no link structure at all) but has fallback href.
+    // If the raw text still has [...]( structure, the user was intentionally
+    // editing the link syntax (e.g., cleared the URL) — don't use fallback.
+    const linkMark = schema.marks.link.create({
+      href: fallbackHref,
+      title: fallbackTitle || null,
+    });
+    tr.replaceWith(nodeFrom, nodeTo, schema.text(raw, [linkMark]));
+  } else {
+    // No valid link data: plain text
+    tr.replaceWith(nodeFrom, nodeTo, schema.text(raw));
+  }
+
+  return true;
+}
+
+/**
+ * Check whether all text nodes in a span share the same set of non-link marks.
+ * Returns the shared mark names (excluding link), or null if they differ.
+ */
+function getSharedInnerMarks(
+  doc: Node,
+  from: number,
+  to: number,
+  linkMarkType: MarkType
+): string[] | null {
+  const $from = doc.resolve(from);
+  const parent = $from.parent;
+  const parentStart = $from.start();
+
+  let offset = parentStart;
+  let sharedNames: string[] | null = null;
+
+  for (let i = 0; i < parent.childCount; i++) {
+    const child = parent.child(i);
+    const childEnd = offset + child.nodeSize;
+
+    if (childEnd <= from) {
+      offset = childEnd;
+      continue;
+    }
+    if (offset >= to) break;
+
+    // This child overlaps the span
+    const nonLinkMarks = child.marks
+      .filter((m) => m.type !== linkMarkType)
+      .map((m) => m.type.name)
+      .filter((name) => SUPPORTED_MARKS.includes(name))
+      .sort();
+
+    const key = nonLinkMarks.join(",");
+
+    if (sharedNames === null) {
+      sharedNames = nonLinkMarks;
+    } else if (sharedNames.join(",") !== key) {
+      return null; // different mark sets -> skip enter
+    }
+
+    offset = childEnd;
+  }
+
+  return sharedNames ?? [];
+}
+
+/**
+ * The `appendTransaction` handler for link source mode transitions.
+ *
+ * Three phases:
+ * 1. Inside link_source (trailing split)
+ * 2. LEAVE: cursor moved outside existing link_source
+ * 3. ENTER: collapsed cursor near a link mark -> replace with link_source node
+ */
+export function handleLinkSourceTransition(
+  _transactions: readonly Transaction[],
+  oldState: EditorState,
+  newState: EditorState
+): Transaction | null {
+  const selectionChanged = !oldState.selection.eq(newState.selection);
+  const docChanged = !oldState.doc.eq(newState.doc);
+  if (!selectionChanged && !docChanged) return null;
+
+  const schema = newState.schema;
+  const linkSourceType = schema.nodes.link_source;
+  if (!linkSourceType) return null;
+
+  const sel = newState.selection as TextSelection;
+  const $cursor = sel.$cursor;
+
+  // Phase 1: Inside link_source — check for trailing split
+  if ($cursor && $cursor.parent.type === linkSourceType) {
+    const raw = $cursor.parent.textContent;
+    const split = findLinkTrailingSplit(raw);
+    if (!split) return null;
+
+    const nodeStart = $cursor.start() - 1; // -1 for node open token
+    const nodeEnd = nodeStart + $cursor.parent.nodeSize;
+
+    const tr = newState.tr;
+
+    const linkMark = schema.marks.link.create({
+      href: split.href,
+      title: split.title || null,
+    });
+    const innerParsed = parseInlineSyntax(split.text);
+    const marks: Mark[] = [linkMark];
+    if (innerParsed.marks.length > 0) {
+      marks.push(...createMarks(schema, innerParsed.marks));
+    }
+    const displayText = innerParsed.marks.length > 0 ? innerParsed.text : split.text;
+    const markedNode = schema.text(displayText, marks);
+    const trailingNode = schema.text(split.trailing);
+
+    tr.replaceWith(nodeStart, nodeEnd, [markedNode, trailingNode]);
+
+    const cursorPos = nodeStart + markedNode.nodeSize + trailingNode.nodeSize;
+    tr.setSelection(TextSelection.create(tr.doc, cursorPos));
+
+    tr.setMeta("addToHistory", false);
+    return tr;
+  }
+
+  // Phase 2: LEAVE — runs for any selection type so non-cursor selections trigger leave
+  const found = findFirstNodeOfType(newState.doc, "link_source");
+
+  if (found) {
+    const nodeFrom = found.pos;
+    const nodeTo = found.pos + found.node.nodeSize;
+
+    // If selection is still inside the link_source node, skip leave.
+    if (sel.from > nodeFrom && sel.to < nodeTo) return null;
+
+    const tr = newState.tr;
+    const fallbackHref = found.node.attrs.href as string;
+    const fallbackTitle = found.node.attrs.title as string;
+    leaveLinkSource(
+      tr,
+      schema,
+      nodeFrom,
+      nodeTo,
+      found.node.textContent,
+      fallbackHref,
+      fallbackTitle
+    );
+    // Clear link mark from stored marks so subsequent typing doesn't
+    // extend the link (ProseMirror inherits marks at the boundary).
+    const linkMT = schema.marks.link;
+    if (linkMT) {
+      tr.setStoredMarks((tr.storedMarks ?? []).filter((m) => m.type !== linkMT));
+    }
+    tr.setMeta("addToHistory", false);
+    return tr;
+  }
+
+  // Phase 3: ENTER — requires collapsed cursor and selection-only change
+  if (!$cursor || docChanged) return null;
+
+  const linkMarkType = schema.marks.link;
+  if (!linkMarkType) return null;
+
+  // Check if cursor is adjacent to a link mark
+  const nodeBefore = $cursor.nodeBefore;
+  const nodeAfter = $cursor.nodeAfter;
+  const marksBefore = nodeBefore?.marks ?? [];
+  const marksAfter = nodeAfter?.marks ?? [];
+
+  // Find a link mark at cursor position (left-biased)
+  const linkBefore = linkMarkType.isInSet(marksBefore);
+  const linkAfter = linkMarkType.isInSet(marksAfter);
+  const targetLink = linkBefore ?? linkAfter;
+
+  if (!targetLink) return null;
+
+  const targetHref = targetLink.attrs.href as string;
+
+  // Find the full extent of the link span
+  const span = findLinkSpan(newState.doc, $cursor.pos, linkMarkType, targetHref);
+  if (!span) return null;
+
+  // Same-boundary inner mark check: only enter source mode when all text nodes
+  // in the link span share the same set of non-link marks.
+  const sharedInnerMarks = getSharedInnerMarks(newState.doc, span.from, span.to, linkMarkType);
+  if (sharedInnerMarks === null) return null; // different mark sets -> skip (deferred to #31)
+
+  // Leave any existing inline_source first (cross-node coordination)
+  const inlineSourceFound = findFirstNodeOfType(newState.doc, "inline_source");
+  const tr = newState.tr;
+  let adjustedFrom = span.from;
+  let adjustedTo = span.to;
+
+  if (inlineSourceFound) {
+    const isNodeFrom = inlineSourceFound.pos;
+    const isNodeTo = inlineSourceFound.pos + inlineSourceFound.node.nodeSize;
+    leaveInlineSource(tr, schema, isNodeFrom, isNodeTo, inlineSourceFound.node.textContent);
+    tr.setMeta("addToHistory", false);
+
+    // Remap span positions through the transaction's mapping to account for
+    // size changes from leaving inline_source (node open/close tokens removed,
+    // content size may change if marks were restored).
+    adjustedFrom = tr.mapping.map(span.from);
+    adjustedTo = tr.mapping.map(span.to);
+  }
+
+  // Build raw text
+  const textContent = tr.doc.textBetween(adjustedFrom, adjustedTo);
+  const title = targetLink.attrs.title as string;
+  const rawText = buildLinkRawText(
+    sharedInnerMarks.length > 0 ? buildRawText(textContent, sharedInnerMarks) : textContent,
+    targetHref,
+    title || undefined
+  );
+
+  // Create link_source node
+  const linkSource = linkSourceType.create(
+    { href: targetHref, title: title || "" },
+    schema.text(rawText)
+  );
+
+  tr.replaceWith(adjustedFrom, adjustedTo, linkSource);
+  tr.setMeta("addToHistory", false);
+
+  // Map cursor position: offset in rendered text -> offset in raw text
+  // raw = "[" + innerMarkPrefix + text + innerMarkSuffix + "](" + href + ")"
+  // The "[" adds 1, plus any inner mark prefix length
+  const innerPrefixLength = computePrefixLength(sharedInnerMarks);
+  const offsetInSpan = $cursor.pos - span.from;
+  const offsetInRaw = offsetInSpan + 1 + innerPrefixLength; // +1 for "["
+
+  // link_source node content starts at adjustedFrom + 1 (after node open)
+  const contentStart = adjustedFrom + 1;
+  const newCursorPos = Math.min(contentStart + offsetInRaw, contentStart + rawText.length);
+  tr.setSelection(TextSelection.create(tr.doc, newCursorPos));
+
+  return tr;
+}
+
+/**
+ * Build inline decorations for `link_source` nodes.
+ * Parses the raw text to find the `](` boundary and applies:
+ * - `.syntax-marker` to `[`, `](`, and `)`
+ * - `.link-url` to the URL (and title if present)
+ */
+export function buildLinkDecorations(state: EditorState): DecorationSet {
+  const linkSourceType = state.schema.nodes.link_source;
+  if (!linkSourceType) return DecorationSet.empty;
+
+  const decorations: Decoration[] = [];
+
+  state.doc.descendants((node, pos) => {
+    if (node.type === linkSourceType) {
+      const raw = node.textContent;
+      const contentStart = pos + 1; // after node open token
+      const contentEnd = pos + node.nodeSize - 1; // before node close token
+
+      // Find `](` boundary in the raw text
+      const closeBracket = raw.indexOf("](");
+
+      if (raw.length > 0 && raw[0] === "[" && closeBracket >= 1 && raw[raw.length - 1] === ")") {
+        // "[" decoration
+        decorations.push(
+          Decoration.inline(contentStart, contentStart + 1, {
+            class: "syntax-marker",
+          })
+        );
+
+        // "](" decoration
+        decorations.push(
+          Decoration.inline(contentStart + closeBracket, contentStart + closeBracket + 2, {
+            class: "syntax-marker",
+          })
+        );
+
+        // URL (and optional title) decoration: from after "](" to before ")"
+        const urlStart = contentStart + closeBracket + 2;
+        const closingParen = contentEnd - 1; // position of ")"
+        if (urlStart < closingParen) {
+          decorations.push(
+            Decoration.inline(urlStart, closingParen, {
+              class: "link-url",
+            })
+          );
+        }
+
+        // ")" decoration
+        decorations.push(
+          Decoration.inline(closingParen, contentEnd, {
+            class: "syntax-marker",
+          })
+        );
+      }
+
+      return false; // don't descend into link_source
+    }
+    return true;
+  });
+
+  return DecorationSet.create(state.doc, decorations);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const linkSourceDecoPlugin = $prose((_ctx) =>
+  makeDecorationPlugin("link-source-deco", buildLinkDecorations)
+);
+
+const linkSourceBehaviorKey = new PluginKey("link-source-behavior");
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const linkSourceBehaviorPlugin = $prose((_ctx) => {
+  let composing = false;
+  let suppressEnter = false;
+  let cmdClickPending = false;
+
+  return new Plugin({
+    key: linkSourceBehaviorKey,
+    appendTransaction(transactions, oldState, newState) {
+      if (composing) return null;
+      // Suppress ENTER during Cmd+click so the link mark stays intact
+      // for handleClick to find (otherwise ENTER may fire between
+      // mousedown and mouseup, replacing the mark with link_source).
+      if (cmdClickPending) return null;
+      const docChanged = !oldState.doc.eq(newState.doc);
+      if (docChanged) suppressEnter = true;
+      if (suppressEnter && !docChanged) {
+        if (!findFirstNodeOfType(newState.doc, "link_source")) return null;
+      }
+      const result = handleLinkSourceTransition(transactions, oldState, newState);
+      if (result) return result;
+
+      // Convert plain text [text](url) to a link mark when cursor leaves it.
+      // This handles the case where the user typed [text](), then went back
+      // to fill in the URL — the input rule can't fire because ) already exists.
+      const oldSel = oldState.selection as TextSelection;
+      const newSel = newState.selection as TextSelection;
+      if (!docChanged && oldSel.$cursor) {
+        const oldPos = oldSel.$cursor.pos;
+        const newPos = newSel.$cursor?.pos ?? newSel.from;
+        if (oldPos !== newPos) {
+          const parent = oldSel.$cursor.parent;
+          if (parent.isTextblock) {
+            const parentStart = oldSel.$cursor.start();
+            const text = parent.textContent;
+            // Scan for [text](url) patterns in the parent's text
+            const re = /\[([^\]]+)\]\(([^)]+)\)/g;
+            let m;
+            while ((m = re.exec(text)) !== null) {
+              const matchFrom = parentStart + m.index;
+              const matchTo = matchFrom + m[0].length;
+              // Was old cursor inside this pattern and new cursor outside?
+              if (
+                oldPos >= matchFrom &&
+                oldPos <= matchTo &&
+                (newPos < matchFrom || newPos > matchTo)
+              ) {
+                const created = createLinkTextNode(newState.schema, m[1]!, normalizeHref(m[2]!));
+                if (!created) break;
+                const tr = newState.tr;
+                tr.replaceWith(matchFrom, matchTo, created.node);
+                tr.removeStoredMark(created.linkMarkType);
+                return tr;
+              }
+            }
+          }
+        }
+      }
+
+      return null;
+    },
+    props: {
+      handleTextInput(view: EditorView, from: number, to: number, text: string) {
+        // Bypass Milkdown/ProseMirror input rules inside link_source.
+        const $from = view.state.doc.resolve(from);
+        const linkSourceType = view.state.schema.nodes.link_source;
+        if (linkSourceType && $from.parent.type === linkSourceType) {
+          view.dispatch(view.state.tr.insertText(text, from, to));
+          return true;
+        }
+
+        return false;
+      },
+      handleKeyDown(view: EditorView, event: KeyboardEvent) {
+        if (NAV_KEYS.has(event.key)) suppressEnter = false;
+
+        const linkSourceType = view.state.schema.nodes.link_source;
+        if (!linkSourceType) return false;
+
+        const { $from } = view.state.selection;
+
+        // Backspace at the start of link_source content: exit source
+        // mode first (restore link mark) so the subsequent paragraph join
+        // preserves formatting instead of leaking raw syntax.
+        if (
+          event.key === "Backspace" &&
+          $from.parent.type === linkSourceType &&
+          $from.parentOffset === 0
+        ) {
+          const nodeStart = $from.start() - 1;
+          const nodeEnd = nodeStart + $from.parent.nodeSize;
+          const tr = view.state.tr;
+          const fallbackHref = $from.parent.attrs.href as string;
+          const fallbackTitle = $from.parent.attrs.title as string;
+          leaveLinkSource(
+            tr,
+            view.state.schema,
+            nodeStart,
+            nodeEnd,
+            $from.parent.textContent,
+            fallbackHref,
+            fallbackTitle
+          );
+          tr.setSelection(TextSelection.create(tr.doc, nodeStart));
+          tr.setMeta("addToHistory", false);
+          view.dispatch(tr);
+          return false;
+        }
+
+        // Cmd+K: create or enter link
+        if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+          event.preventDefault();
+          const schema = view.state.schema;
+          const sel = view.state.selection as TextSelection;
+
+          // No-op if already inside link_source
+          if ($from.parent.type === linkSourceType) return true;
+
+          const linkMarkType = schema.marks.link;
+
+          // Case 1: Cursor on an existing rendered link — trigger appendTransaction enter
+          if (sel.$cursor) {
+            const nodeBefore = sel.$cursor.nodeBefore;
+            const nodeAfter = sel.$cursor.nodeAfter;
+            const linkBefore = linkMarkType.isInSet(nodeBefore?.marks ?? []);
+            const linkAfter = linkMarkType.isInSet(nodeAfter?.marks ?? []);
+            if (linkBefore || linkAfter) {
+              const tr = view.state.tr.setSelection(view.state.selection);
+              tr.setMeta("addToHistory", false);
+              view.dispatch(tr);
+              return true;
+            }
+          }
+
+          // Case 2: Text is selected — wrap as [selected text]()
+          if (!sel.empty) {
+            const selectedText = view.state.doc.textBetween(sel.from, sel.to);
+            const rawText = `[${selectedText}]()`;
+            const linkSource = linkSourceType.create({ href: "", title: "" }, schema.text(rawText));
+            const tr = view.state.tr.replaceWith(sel.from, sel.to, linkSource);
+            // Place cursor inside parens: after "]("
+            // Content starts at sel.from + 1 (node open token)
+            // Position after "](" = contentStart + "[".length + selectedText.length + "](".length
+            const contentStart = sel.from + 1;
+            const cursorPos = contentStart + 1 + selectedText.length + 2;
+            tr.setSelection(TextSelection.create(tr.doc, cursorPos));
+            view.dispatch(tr);
+            return true;
+          }
+
+          // Case 3: No selection — insert empty link syntax
+          const rawText = "[]()";
+          const linkSource = linkSourceType.create({ href: "", title: "" }, schema.text(rawText));
+          const pos = sel.from;
+          const tr = view.state.tr.replaceWith(pos, pos, linkSource);
+          // Place cursor inside brackets: after "["
+          // Content starts at pos + 1 (node open token), cursor after "[" = contentStart + 1
+          const contentStart = pos + 1;
+          tr.setSelection(TextSelection.create(tr.doc, contentStart + 1));
+          view.dispatch(tr);
+          return true;
+        }
+
+        return false;
+      },
+      handleDOMEvents: {
+        compositionstart: () => {
+          composing = true;
+          return false;
+        },
+        compositionend: () => {
+          composing = false;
+          return false;
+        },
+        mousedown: (_: EditorView, event: MouseEvent) => {
+          suppressEnter = false;
+          cmdClickPending = !!(event.metaKey || event.ctrlKey);
+          return false;
+        },
+      },
+      handleClick(view: EditorView, pos: number, event: MouseEvent) {
+        cmdClickPending = false;
+        if (!(event.metaKey || event.ctrlKey)) return false;
+
+        const linkMarkType = view.state.schema.marks.link;
+        if (!linkMarkType) return false;
+
+        const $pos = view.state.doc.resolve(pos);
+        const linkMark =
+          linkMarkType.isInSet($pos.nodeBefore?.marks ?? []) ??
+          linkMarkType.isInSet($pos.nodeAfter?.marks ?? []);
+        if (!linkMark) return false;
+
+        const href = linkMark.attrs.href as string;
+        if (!href) return false;
+
+        event.preventDefault();
+        import("@tauri-apps/plugin-opener")
+          .then(({ openUrl }) => openUrl(href))
+          .catch((err) => console.error("Failed to open URL:", href, err));
+        return true;
+      },
+    },
+  });
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const linkInputRulePlugin = $prose((_ctx) => {
+  const rule = new InputRule(LINK_INPUT_RULE_REGEX, (state, match, start, end) => {
+    // Don't fire inside link_source
+    const $from = state.doc.resolve(start);
+    const linkSourceType = state.schema.nodes.link_source;
+    if (linkSourceType && $from.parent.type === linkSourceType) return null;
+
+    const created = createLinkTextNode(state.schema, match[1]!, normalizeHref(match[2]!));
+    if (!created) return null;
+    const tr = state.tr.replaceWith(start, end, created.node);
+    tr.removeStoredMark(created.linkMarkType);
+    return tr;
+  });
+
+  return inputRules({ rules: [rule] });
+});
+
+export const linkSourcePlugin = [
+  linkSourceDecoPlugin,
+  linkSourceBehaviorPlugin,
+  linkInputRulePlugin,
+].flat();

--- a/ui/plugins/link-source/syntax.ts
+++ b/ui/plugins/link-source/syntax.ts
@@ -1,0 +1,89 @@
+export interface ParsedLink {
+  text: string;
+  href: string;
+  title: string;
+}
+
+const TITLE_REGEX = /^(.+?)\s+"([^"]*)"$/;
+const HAS_PROTOCOL = /^[a-z][a-z0-9+.-]*:/i;
+
+/** Prepend https:// if href has no protocol and isn't a relative/anchor path. */
+export function normalizeHref(href: string): string {
+  if (!href || HAS_PROTOCOL.test(href) || href[0] === "/" || href[0] === "#") {
+    return href;
+  }
+  return `https://${href}`;
+}
+
+export function parseLinkSyntax(raw: string): ParsedLink | null {
+  if (!raw || raw[0] !== "[") return null;
+
+  const closeBracket = raw.indexOf("](");
+  if (closeBracket < 1) return null;
+
+  const text = raw.slice(1, closeBracket);
+  if (!text) return null;
+
+  if (raw[raw.length - 1] !== ")") return null;
+
+  const urlPart = raw.slice(closeBracket + 2, raw.length - 1);
+  if (!urlPart) return null;
+
+  let href = urlPart;
+  let title = "";
+
+  const titleMatch = urlPart.match(TITLE_REGEX);
+  if (titleMatch) {
+    href = titleMatch[1]!;
+    title = titleMatch[2]!;
+  }
+
+  if (!href) return null;
+
+  return { text, href: normalizeHref(href), title };
+}
+
+/**
+ * Regex for matching typed link syntax. Excludes ] from text and ) from URL
+ * to prevent greedy over-matching across multiple links.
+ */
+export const LINK_INPUT_RULE_REGEX = /\[([^\]]+)\]\(([^)]+)\)$/;
+
+export function buildLinkRawText(text: string, href: string, title?: string): string {
+  if (title) {
+    return `[${text}](${href} "${title}")`;
+  }
+  return `[${text}](${href})`;
+}
+
+export interface LinkTrailingSplit {
+  text: string;
+  href: string;
+  title: string;
+  trailing: string;
+}
+
+export function findLinkTrailingSplit(raw: string): LinkTrailingSplit | null {
+  if (!raw || raw[0] !== "[") return null;
+
+  // If the whole string is already a valid link, no split needed.
+  if (parseLinkSyntax(raw)) return null;
+
+  // Scan backwards for the last `)` that completes a valid link pattern.
+  for (let i = raw.length - 2; i >= 3; i--) {
+    if (raw[i] !== ")") continue;
+
+    const candidate = raw.slice(0, i + 1);
+    const parsed = parseLinkSyntax(candidate);
+    if (parsed) {
+      return {
+        text: parsed.text,
+        href: parsed.href,
+        title: parsed.title,
+        trailing: raw.slice(i + 1),
+      };
+    }
+  }
+
+  return null;
+}

--- a/ui/plugins/shared/marks.ts
+++ b/ui/plugins/shared/marks.ts
@@ -1,0 +1,21 @@
+import type { Mark, MarkType } from "@milkdown/kit/prose/model";
+
+/** Build Mark[] from mark names, filtering any that don't exist in the schema. */
+export function createMarks(
+  schema: { marks: Record<string, MarkType> },
+  markNames: string[]
+): Mark[] {
+  return markNames.map((name) => schema.marks[name]?.create()).filter((m): m is Mark => m != null);
+}
+
+/** Keys that represent intentional cursor navigation. */
+export const NAV_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);

--- a/ui/theme/skriv.css
+++ b/ui/theme/skriv.css
@@ -138,6 +138,21 @@ body,
   opacity: 0.4;
 }
 
+.milkdown .editor .link-source {
+  font-family: inherit;
+  border-radius: 2px;
+  background: var(--crepe-color-inline-area, #f5f5f5);
+  caret-color: var(--crepe-color-on-background, #333);
+}
+
+.milkdown .editor .link-source .syntax-marker {
+  opacity: 0.4;
+}
+
+.milkdown .editor .link-source .link-url {
+  opacity: 0.6;
+}
+
 .milkdown .editor .heading-source .syntax-marker {
   opacity: 0.4;
 }


### PR DESCRIPTION
## Summary

- Typora-style link editing: cursor-enter reveals `[text](url)` inline, cursor-leave collapses back to rendered link
- Cmd+K creates links inline (with selection wrapping and clipboard URL auto-fill)
- Typing `[text](url)` converts to a link mark via input rule
- Cmd+click follows links via Tauri's opener plugin
- Same-boundary inner marks supported (e.g., `[**bold**](url)`)
- Cross-node coordination with `inline_source` ensures mutual exclusion
- Coexists with Crepe's LinkTooltip for hover previews

## New Files

- `ui/plugins/link-source/` — syntax.ts, node.ts, plugin.ts, index.ts
- `ui/plugins/shared/marks.ts` — extracted `createMarks` and `NAV_KEYS`

## Modified Files

- `ui/components/Editor.tsx` — plugin registration
- `ui/plugins/inline-source/plugin.ts` — cross-node coordination, shared imports
- `ui/theme/skriv.css` — link-source styles

## Test Plan

- [x] Click on a rendered link → raw `[text](url)` revealed, editable
- [x] Arrow keys navigate within the raw syntax
- [x] Click away or arrow out → collapses back to rendered link
- [x] Incomplete syntax on leave (e.g., delete URL) → degrades to plain text
- [x] Cmd+K with selection → wraps as `[selection]()`, cursor in parens
- [x] Cmd+K without selection → inserts `[]()`, cursor in brackets
- [x] Type `[text](url)` → converts to link on closing `)`
- [x] Subsequent typing after link doesn't extend the link mark
- [x] Cmd+click → opens URL in system browser
- [x] Bold link `[**bold**](url)` → syntax reveals with inner marks
- [x] Cross-node: enter inline mark source, click link → inline closes, link opens
- [x] LinkTooltip: hover rendered link → tooltip appears; click → source mode, tooltip gone