### PR TITLE
feat: Cmd+K clipboard auto-fill via Tauri clipboard plugin (#56)

### DIFF
--- a/docs/superpowers/specs/2026-03-25-clipboard-autofill-design.md
+++ b/docs/superpowers/specs/2026-03-25-clipboard-autofill-design.md
@@ -69,7 +69,7 @@ Any failure — clipboard empty, not a URL, plugin error, exception — silently
 ### Cursor Positioning
 
 **Case 2 (text selected):**
-- **With clipboard URL:** `[text](https://example.com)|` — cursor after closing paren (link is complete, user continues typing prose). Matches Typora behavior.
+- **With clipboard URL:** `[text](https://example.com|)` — cursor at end of URL inside parens, keeping `link_source` node open so the user can review/edit the URL before navigating away.
 - **Without clipboard URL:** `[text](|)` — cursor inside empty parens, same as current behavior.
 
 **Case 3 (no selection):**
@@ -80,7 +80,7 @@ Any failure — clipboard empty, not a URL, plugin error, exception — silently
 
 | Scenario | Expected result |
 |----------|-----------------|
-| Clipboard has valid `https://` URL, text selected | `[text](clipboard-url)`, cursor after `)` |
+| Clipboard has valid `https://` URL, text selected | `[text](clipboard-url)`, cursor at end of URL inside parens |
 | Clipboard has valid `http://` URL, no selection | `[](clipboard-url)`, cursor inside `[]` |
 | Clipboard has plain text (not a URL) | Falls back to empty parens |
 | Clipboard is empty | Falls back to empty parens |

--- a/docs/superpowers/specs/2026-03-25-clipboard-autofill-design.md
+++ b/docs/superpowers/specs/2026-03-25-clipboard-autofill-design.md
@@ -1,0 +1,100 @@
+# Cmd+K Clipboard Auto-Fill via Tauri Clipboard Plugin
+
+**Issue:** #56
+**Date:** 2026-03-25
+
+## Problem
+
+When creating a link with Cmd+K, the URL field is always empty. Typora auto-fills the URL from the clipboard if it contains a valid HTTP/HTTPS URL. The original design doc specified `navigator.clipboard.readText()`, but this triggers a browser permission prompt in the Tauri webview, so it was never implemented.
+
+## Solution
+
+Add `@tauri-apps/plugin-clipboard-manager` to read the clipboard through Tauri's native IPC, bypassing the browser permission prompt.
+
+## Changes
+
+### Backend (Tauri)
+
+- Add `tauri-plugin-clipboard-manager` crate to `src-tauri/Cargo.toml`
+- Register plugin in `src-tauri/src/lib.rs` via `.plugin(tauri_plugin_clipboard_manager::init())`
+- Add `clipboard-manager:default` permission to `src-tauri/capabilities/default.json`
+
+### Frontend (JS)
+
+- Add `@tauri-apps/plugin-clipboard-manager` to `package.json`
+- Add `readClipboardUrl()` helper to `ui/plugins/link-source/plugin.ts`:
+  1. Call `readText()` from `@tauri-apps/plugin-clipboard-manager`
+  2. Validate with `try { new URL(text) }` — accept only `http:` and `https:` protocols
+  3. Return the URL string or `null` on any failure
+- Modify Cmd+K handler Cases 2 (text selected) and 3 (no selection) to use the clipboard URL
+
+### Async Strategy
+
+`handleKeyDown` is synchronous and must return `boolean`. The handler uses a two-phase dispatch:
+
+**Phase 1 (synchronous):** Create the `link_source` node with empty parens exactly as today. Return `true` to claim the keypress.
+
+**Phase 2 (async callback):** Read the clipboard, validate the URL, and if valid, dispatch a second transaction to fill in the URL.
+
+```
+Cmd+K pressed
+  -> Phase 1: dispatch [text]() or [](), position cursor (same as today)
+  -> return true (claim keypress)
+  -> Phase 2 (async): readClipboardUrl()
+    -> valid URL: dispatch second transaction to fill parens with URL
+    -> no URL / failure: do nothing (Phase 1 result stands)
+```
+
+**Async safety:** The Phase 2 callback must:
+- Re-derive `view.state` at dispatch time (not close over the stale state from Phase 1)
+- Verify the `link_source` node still exists at the expected position
+- Check that the URL portion is still empty (guard against the user having already started typing)
+
+If any of these checks fail, Phase 2 silently does nothing.
+
+### URL Validation
+
+A clipboard string is treated as a URL only if:
+- It parses successfully via `new URL(text)`
+- The parsed URL protocol is `http:` or `https:`
+
+Everything else (plain text, file paths, `javascript:` URIs, etc.) is ignored.
+
+Note: We use `try { new URL(text) }` instead of `URL.canParse()` for broader webview compatibility (`URL.canParse()` requires Safari 17+ / macOS Sonoma 14+).
+
+### Error Handling
+
+Any failure — clipboard empty, not a URL, plugin error, exception — silently falls back to the current behavior (empty parens from Phase 1). No user-facing error messages.
+
+### Cursor Positioning
+
+**Case 2 (text selected):**
+- **With clipboard URL:** `[text](https://example.com)|` — cursor after closing paren (link is complete, user continues typing prose). Matches Typora behavior.
+- **Without clipboard URL:** `[text](|)` — cursor inside empty parens, same as current behavior.
+
+**Case 3 (no selection):**
+- **With clipboard URL:** `[|](https://example.com)` — cursor inside brackets so the user can type link text. Matches Typora behavior.
+- **Without clipboard URL:** `[|]()` — cursor inside brackets, same as current behavior.
+
+## Test Scenarios
+
+| Scenario | Expected result |
+|----------|-----------------|
+| Clipboard has valid `https://` URL, text selected | `[text](clipboard-url)`, cursor after `)` |
+| Clipboard has valid `http://` URL, no selection | `[](clipboard-url)`, cursor inside `[]` |
+| Clipboard has plain text (not a URL) | Falls back to empty parens |
+| Clipboard is empty | Falls back to empty parens |
+| Clipboard has `javascript:alert(1)` | Rejected — not http/https |
+| Clipboard has `file:///path` | Rejected — not http/https |
+| Clipboard read fails (plugin error) | Falls back to empty parens |
+| User types in URL field before async completes | Phase 2 does nothing (URL field no longer empty) |
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src-tauri/Cargo.toml` | Add `tauri-plugin-clipboard-manager` dependency |
+| `src-tauri/src/lib.rs` | Register clipboard manager plugin |
+| `src-tauri/capabilities/default.json` | Add `clipboard-manager:default` permission |
+| `package.json` | Add `@tauri-apps/plugin-clipboard-manager` |
+| `ui/plugins/link-source/plugin.ts` | Add `readClipboardUrl()`, update Cmd+K handler |

--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -13,6 +13,8 @@ export interface TauriMockConfig {
   fileInfo?: { size: number; modified: number };
   /** Whether write_file should succeed — default: true */
   writeShouldSucceed?: boolean;
+  /** Response for clipboard readText — default: "" (empty clipboard) */
+  clipboardText?: string;
 }
 
 const DEFAULT_CONFIG: Required<TauriMockConfig> = {
@@ -20,6 +22,7 @@ const DEFAULT_CONFIG: Required<TauriMockConfig> = {
   fileContent: "",
   fileInfo: { size: 100, modified: 0 },
   writeShouldSucceed: true,
+  clipboardText: "",
 };
 
 /**
@@ -104,6 +107,10 @@ export async function injectTauriMock(
 
         case "unwatch_file":
           return undefined;
+
+        // Clipboard plugin
+        case "plugin:clipboard-manager|read_text":
+          return cfg.clipboardText;
 
         // Dialog plugin
         case "plugin:dialog|open":

--- a/e2e/tests/link-clipboard.spec.ts
+++ b/e2e/tests/link-clipboard.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, MOD } from "../fixtures";
+
+test.describe("Cmd+K clipboard auto-fill", () => {
+  test("Cmd+K with clipboard URL and text selected wraps text in a link", async ({
+    page,
+    loadApp,
+  }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: "hello\n",
+      clipboardText: "https://example.com",
+    });
+    const editor = page.locator(".milkdown .editor");
+    await editor.click();
+
+    // Select all text then trigger Cmd+K
+    await page.keyboard.press(`${MOD}+a`);
+    await page.keyboard.press(`${MOD}+k`);
+
+    // Phase 2 fills URL but keeps link-source open for review
+    await expect(editor.locator(".link-source")).toContainText(
+      "[hello](https://example.com)",
+      { timeout: 5_000 },
+    );
+  });
+
+  test("Cmd+K with clipboard URL and no selection inserts link-source with URL", async ({
+    page,
+    loadApp,
+  }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: "hello\n",
+      clipboardText: "https://example.com",
+    });
+    const editor = page.locator(".milkdown .editor");
+    await editor.click();
+
+    // Move cursor to end of line (no selection)
+    await page.keyboard.press("End");
+    await page.keyboard.press(`${MOD}+k`);
+
+    // With no selection the link-source node stays visible with the URL filled in
+    await expect(editor.locator(".link-source")).toContainText(
+      "[](https://example.com)",
+      { timeout: 5_000 },
+    );
+  });
+
+  test("Cmd+K with non-URL clipboard text leaves empty parens", async ({
+    page,
+    loadApp,
+  }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: "hello\n",
+      clipboardText: "just plain text",
+    });
+    const editor = page.locator(".milkdown .editor");
+    await editor.click();
+
+    // Select all text then trigger Cmd+K
+    await page.keyboard.press(`${MOD}+a`);
+    await page.keyboard.press(`${MOD}+k`);
+
+    // Non-URL clipboard means fallback — link-source stays with empty parens
+    await expect(editor.locator(".link-source")).toContainText("[hello]()", {
+      timeout: 5_000,
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@milkdown/react": "^7.19.1",
     "@milkdown/utils": "^7.19.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "codemirror": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.6.0
         version: 2.6.0
@@ -791,6 +794,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
@@ -3565,6 +3571,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
+tauri-plugin-clipboard-manager = "2.3.2"
 notify = "8"
 
 [dev-dependencies]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-set-title",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    "clipboard-manager:allow-read-text"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@ pub fn run() {
         .manage(watcher::FileWatcher::new())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .invoke_handler(tauri::generate_handler![
             commands::read_file,
             commands::write_file,

--- a/ui/__tests__/plugins/link-source/clipboard.test.ts
+++ b/ui/__tests__/plugins/link-source/clipboard.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Declare mock via vi.hoisted so it is available when vi.mock factory runs
+const { mockReadText } = vi.hoisted(() => ({ mockReadText: vi.fn() }));
+
+// Mock the Tauri clipboard plugin module
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: mockReadText,
+}));
+
+import { readClipboardUrl } from "../../../plugins/link-source/clipboard";
+
+describe("readClipboardUrl", () => {
+  beforeEach(() => {
+    mockReadText.mockReset();
+  });
+
+  it("returns a valid https URL from clipboard", async () => {
+    mockReadText.mockResolvedValue("https://example.com");
+    expect(await readClipboardUrl()).toBe("https://example.com");
+  });
+
+  it("returns a valid http URL from clipboard", async () => {
+    mockReadText.mockResolvedValue("http://example.com/page?q=1");
+    expect(await readClipboardUrl()).toBe("http://example.com/page?q=1");
+  });
+
+  it("returns null for plain text", async () => {
+    mockReadText.mockResolvedValue("just some text");
+    expect(await readClipboardUrl()).toBeNull();
+  });
+
+  it("returns null for empty clipboard", async () => {
+    mockReadText.mockResolvedValue("");
+    expect(await readClipboardUrl()).toBeNull();
+  });
+
+  it("returns null for javascript: URI", async () => {
+    mockReadText.mockResolvedValue("javascript:alert(1)");
+    expect(await readClipboardUrl()).toBeNull();
+  });
+
+  it("returns null for file: URI", async () => {
+    mockReadText.mockResolvedValue("file:///etc/passwd");
+    expect(await readClipboardUrl()).toBeNull();
+  });
+
+  it("returns null for mailto: URI", async () => {
+    mockReadText.mockResolvedValue("mailto:user@example.com");
+    expect(await readClipboardUrl()).toBeNull();
+  });
+
+  it("returns null when readText throws", async () => {
+    mockReadText.mockRejectedValue(new Error("clipboard error"));
+    expect(await readClipboardUrl()).toBeNull();
+  });
+
+  it("trims whitespace from clipboard text", async () => {
+    mockReadText.mockResolvedValue("  https://example.com  \n");
+    expect(await readClipboardUrl()).toBe("https://example.com");
+  });
+
+  it("returns null when readText resolves to null", async () => {
+    mockReadText.mockResolvedValue(null);
+    expect(await readClipboardUrl()).toBeNull();
+  });
+});

--- a/ui/plugins/link-source/clipboard.ts
+++ b/ui/plugins/link-source/clipboard.ts
@@ -1,0 +1,20 @@
+import { readText } from "@tauri-apps/plugin-clipboard-manager";
+
+/**
+ * Read the clipboard and return its content if it's a valid HTTP/HTTPS URL.
+ * Returns null on any failure or non-URL content.
+ */
+export async function readClipboardUrl(): Promise<string | null> {
+  try {
+    const raw = await readText();
+    const text = (raw ?? "").trim();
+    if (!text) return null;
+    const url = new URL(text);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return text;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/ui/plugins/link-source/plugin.ts
+++ b/ui/plugins/link-source/plugin.ts
@@ -27,6 +27,7 @@ import {
   normalizeHref,
   parseLinkSyntax,
 } from "./syntax";
+import { readClipboardUrl } from "./clipboard";
 
 /** Create a text node with a link mark and optional inner marks from raw link text. */
 function createLinkTextNode(
@@ -458,6 +459,48 @@ const linkSourceDecoPlugin = $prose((_ctx) =>
   makeDecorationPlugin("link-source-deco", buildLinkDecorations)
 );
 
+/**
+ * Phase 2 of Cmd+K clipboard auto-fill. After Phase 1 creates the link_source
+ * node with empty parens, this reads the clipboard and fills the URL if valid.
+ */
+async function fillUrlFromClipboard(view: EditorView, selectedTextLen: number): Promise<void> {
+  const url = await readClipboardUrl();
+  if (!url) return;
+
+  // Re-derive state — it may have changed since Phase 1.
+  // Find the link_source node by type rather than saved position,
+  // because AllSelection (Cmd+A) can cause replaceWith to auto-wrap
+  // the node in a paragraph, shifting its position.
+  const state = view.state;
+  const found = findFirstNodeOfType(state.doc, "link_source");
+  if (!found) return;
+
+  const { node, pos: nodePos } = found;
+  const rawText = node.textContent;
+
+  // Bail if user has started typing in the URL field
+  if (!rawText.endsWith("]()")) return;
+  if (rawText.length - "[]()".length !== selectedTextLen) return;
+
+  const linkText = selectedTextLen > 0 ? rawText.slice(1, 1 + selectedTextLen) : "";
+  const newRawText = buildLinkRawText(linkText, url);
+
+  const linkSourceType = state.schema.nodes.link_source;
+  const newNode = linkSourceType.create({ href: "", title: "" }, state.schema.text(newRawText));
+  const tr = state.tr.replaceWith(nodePos, nodePos + node.nodeSize, newNode);
+
+  const contentStart = nodePos + 1;
+  if (selectedTextLen > 0) {
+    // Keep link_source open so user can review the auto-filled URL
+    const endOfUrl = contentStart + newRawText.length - 1;
+    tr.setSelection(TextSelection.create(tr.doc, endOfUrl));
+  } else {
+    tr.setSelection(TextSelection.create(tr.doc, contentStart + 1));
+  }
+
+  view.dispatch(tr);
+}
+
 const linkSourceBehaviorKey = new PluginKey("link-source-behavior");
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -601,12 +644,13 @@ const linkSourceBehaviorPlugin = $prose((_ctx) => {
             const linkSource = linkSourceType.create({ href: "", title: "" }, schema.text(rawText));
             const tr = view.state.tr.replaceWith(sel.from, sel.to, linkSource);
             // Place cursor inside parens: after "]("
-            // Content starts at sel.from + 1 (node open token)
-            // Position after "](" = contentStart + "[".length + selectedText.length + "](".length
             const contentStart = sel.from + 1;
             const cursorPos = contentStart + 1 + selectedText.length + 2;
             tr.setSelection(TextSelection.create(tr.doc, cursorPos));
             view.dispatch(tr);
+
+            // Phase 2: async clipboard auto-fill
+            void fillUrlFromClipboard(view, selectedText.length);
             return true;
           }
 
@@ -616,10 +660,12 @@ const linkSourceBehaviorPlugin = $prose((_ctx) => {
           const pos = sel.from;
           const tr = view.state.tr.replaceWith(pos, pos, linkSource);
           // Place cursor inside brackets: after "["
-          // Content starts at pos + 1 (node open token), cursor after "[" = contentStart + 1
           const contentStart = pos + 1;
           tr.setSelection(TextSelection.create(tr.doc, contentStart + 1));
           view.dispatch(tr);
+
+          // Phase 2: async clipboard auto-fill
+          void fillUrlFromClipboard(view, 0);
           return true;
         }
 


### PR DESCRIPTION
## Summary

- Add `@tauri-apps/plugin-clipboard-manager` (Rust crate + JS package + capability) to read the clipboard via Tauri's native IPC, bypassing browser permission prompts
- When Cmd+K creates a link, auto-fill the URL from the clipboard if it contains a valid HTTP/HTTPS URL (two-phase async: synchronous node creation, then async clipboard read + fill)
- Add `readClipboardUrl()` helper with 10 unit tests and 3 Playwright e2e tests

## Test Plan

- [x] Unit tests: 10 cases for `readClipboardUrl` (valid URLs, invalid schemes, empty, null, errors, whitespace)
- [x] Existing tests: 347 tests pass with no regressions
- [x] E2e tests: Cmd+K with clipboard URL + selection, no selection, non-URL fallback
- [ ] Manual smoke test: `make dev` → copy URL → select text → Cmd+K → verify auto-fill

Closes #56