### PR TITLE
fix: prevent inline code overflow in table cells

### DIFF
--- a/ui/theme/skriv.css
+++ b/ui/theme/skriv.css
@@ -120,6 +120,13 @@ body,
   border: 1px solid var(--crepe-color-outline, #ddd);
   padding: 8px 12px;
   text-align: left;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.milkdown .editor th code,
+.milkdown .editor td code {
+  word-break: break-all;
 }
 
 .milkdown .editor th {


### PR DESCRIPTION
Closes #62

## Summary
- Add `overflow-wrap: break-word` and `word-break: break-word` to `th`/`td` elements so long content respects column boundaries
- Add `word-break: break-all` specifically to `code` elements inside table cells so long inline code (e.g. file paths, package names) wraps instead of overflowing into adjacent columns

## Test plan
- [ ] Create a table with long inline code like `` `src-tauri/capabilities/default.json` `` in a cell
- [ ] Verify inline code wraps within the cell boundary instead of overflowing
- [ ] Verify normal (short) inline code in tables still renders correctly
- [ ] Verify tables without inline code are unaffected