### PR TITLE
Add expandable table-of-contents sidebar for heading navigation

### DIFF
--- a/docs/plans/2026-03-27-toc-sidebar-design.md
+++ b/docs/plans/2026-03-27-toc-sidebar-design.md
@@ -1,0 +1,115 @@
+# TOC Sidebar Design
+
+**Issue:** #19 — Add expandable table-of-contents sidebar for heading navigation
+
+## Overview
+
+A collapsible left sidebar that displays a table of contents derived from the document's headings. Users can click headings to navigate, and scroll-spy highlights the currently visible heading. Works in both WYSIWYG and source mode.
+
+## Component Architecture
+
+### New Files
+
+- `ui/components/TocSidebar.tsx` — sidebar shell (collapse toggle, header, heading list, active highlight)
+- `ui/hooks/useToc.ts` — hook that bridges both editors, returns headings, active index, and scroll-to function
+
+### Shared Types
+
+```typescript
+interface TocHeading {
+  level: number;   // 1-6
+  text: string;    // heading text content
+  pos: number;     // editor offset (PM doc position or CM line offset)
+}
+```
+
+Both extractors produce `TocHeading[]`. The sidebar component consumes this array and a `scrollToHeading(pos: number)` callback — it has no knowledge of which editor is active.
+
+### Data Flow
+
+```
+App.tsx
+├── TocSidebar (left column, collapsible)
+│   └── Renders TocHeading[], highlights activeIndex
+├── Editor column (flex: 1)
+│   ├── SearchBar
+│   └── MarkdownEditor / SourceEditor
+```
+
+`useToc` receives `editorRef` and `sourceMode`. It swaps between ProseMirror and CodeMirror extraction based on the active mode and exposes:
+
+- `headings: TocHeading[]`
+- `activeIndex: number`
+- `scrollToHeading: (pos: number) => void`
+
+## Layout
+
+The current single-column flex layout in `App.tsx` becomes two columns:
+
+```
+┌──────────────────────────────────────────┐
+│ Banner area (full width, unchanged)      │
+├───────────┬──────────────────────────────┤
+│ TOC       │ Editor container             │
+│ Sidebar   │ (flex: 1, overflow: auto)    │
+│ ~220px    │                              │
+│           │ .milkdown / .source-editor   │
+│ collapses │ max-width: 860px, centered   │
+│ to 0px    │                              │
+├───────────┴──────────────────────────────┤
+```
+
+- Banners remain full-width above both columns.
+- A flex row wraps the sidebar and editor container.
+- Sidebar has a fixed width (~220px) with CSS transition to 0 when collapsed.
+- Editor column is `flex: 1` — takes remaining space.
+- Editor's `max-width` and `margin: 0 auto` centering is unchanged.
+- The editor column is a **CSS container** so that future responsive breakpoints (#11) can use container queries instead of media queries, making them independent of sidebar state.
+
+## Heading Extraction
+
+### WYSIWYG Mode (ProseMirror)
+
+A ProseMirror plugin view listens to document updates. On each update, it walks the doc tree via `doc.descendants()`, collecting `heading` and `heading_source` nodes. For each, it extracts `{ level: node.attrs.level, text: node.textContent, pos }` and pushes the list to React state via a callback.
+
+### Source Mode (CodeMirror)
+
+A CodeMirror `ViewPlugin` re-evaluates on document changes. It scans lines for the ATX heading pattern (`/^(#{1,6})\s+(.+)/`), extracting `{ level, text, pos: lineStartOffset }` for each match. It pushes to the same React state via callback.
+
+### Interface Boundary
+
+Both extractors produce `TocHeading[]`. The `useToc` hook swaps the active extractor when `sourceMode` changes. The sidebar and scroll-spy logic are completely decoupled from the editor internals.
+
+## Scroll-spy
+
+Listens to the scroll event on the editor's scroll container (the `overflow: auto` div). On scroll, determines the active heading — the last heading whose top edge is at or above a threshold (~20% from viewport top). Updates `activeIndex` in `useToc`. The TOC sidebar highlights the active entry and auto-scrolls it into view if the heading list overflows.
+
+## Click-to-Navigate
+
+- **WYSIWYG:** Dispatches a ProseMirror transaction to set selection at `pos`, then `scrollIntoView`.
+- **Source:** Uses CodeMirror `dispatch` to set cursor at `pos` and `scrollIntoView`.
+- Both wrapped behind `scrollToHeading(pos: number)`.
+
+## Toggle & Persistence
+
+### Toggle Button
+
+- When open: a collapse icon in the sidebar header.
+- When closed: a small icon button fixed at the left edge of the editor area.
+- Keyboard shortcut: `Cmd+Shift+L` (`Ctrl+Shift+L` on non-Mac).
+
+### State Persistence
+
+- Open/closed state saved to `localStorage`.
+- Default: collapsed (writing-first experience).
+
+### Animation
+
+CSS transition on sidebar width (`220px` → `0`) with `overflow: hidden`. Editor column resizes smoothly via flexbox.
+
+## Edge Cases
+
+- **No headings:** Sidebar shows subtle "No headings" empty state.
+- **Heading at document bottom:** Scroll as far as possible, still mark active.
+- **`heading_source` nodes:** Treated the same as `heading` for extraction (cursor is inside a heading in WYSIWYG mode).
+- **Rapid editing:** Heading extraction is debounced or throttled to avoid excessive updates during fast typing.

--- a/docs/plans/2026-03-27-toc-sidebar-design.md
+++ b/docs/plans/2026-03-27-toc-sidebar-design.md
@@ -107,6 +107,22 @@ Listens to the scroll event on the editor's scroll container (the `overflow: aut
 
 CSS transition on sidebar width (`220px` → `0`) with `overflow: hidden`. Editor column resizes smoothly via flexbox.
 
+## Testing
+
+### Unit Tests (Vitest)
+
+- **ProseMirror heading extraction:** Given a PM doc with various heading levels, verify correct `TocHeading[]` output. Test `heading` and `heading_source` nodes, nested content, and empty documents.
+- **CodeMirror heading extraction:** Given raw markdown text, verify correct `TocHeading[]` output. Test all heading levels, headings with inline formatting, lines that look like headings but aren't (e.g., inside code blocks).
+- **TocSidebar component:** Renders heading list with correct indentation per level. Highlights active index. Shows empty state when no headings. Calls `scrollToHeading` on click.
+
+### E2E Tests (Playwright)
+
+- **Toggle sidebar:** Open sidebar via keyboard shortcut and toggle button, verify it appears/disappears.
+- **Heading list populates:** Open a markdown file with headings, open sidebar, verify headings appear with correct hierarchy.
+- **Click-to-navigate:** Click a TOC entry, verify the editor scrolls to that heading.
+- **Real-time update:** Add a new heading in the editor, verify it appears in the TOC without manual refresh.
+- **Source mode:** Switch to source mode, verify TOC still shows headings and click-to-navigate works.
+
 ## Edge Cases
 
 - **No headings:** Sidebar shows subtle "No headings" empty state.

--- a/e2e/tests/toc-sidebar.spec.ts
+++ b/e2e/tests/toc-sidebar.spec.ts
@@ -1,0 +1,196 @@
+// e2e/tests/toc-sidebar.spec.ts
+import { test, expect, MOD } from "../fixtures";
+
+const TOC_CONTENT = `# Introduction
+
+Some introductory text here.
+
+## Background
+
+Background information and context.
+
+### Details
+
+Detailed explanation of the background.
+
+## Architecture
+
+How the system is built.
+
+## Conclusion
+
+Final thoughts.
+`;
+
+test.describe("TOC Sidebar", () => {
+  test("Cmd+Shift+L toggles sidebar open and closed", async ({ page, loadApp }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: TOC_CONTENT,
+    });
+
+    // Sidebar should be closed by default
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar).toHaveClass(/toc-sidebar--collapsed/);
+
+    // Open via shortcut
+    await page.keyboard.press(`${MOD}+Shift+l`);
+    await expect(sidebar).not.toHaveClass(/toc-sidebar--collapsed/);
+
+    // Close via shortcut
+    await page.keyboard.press(`${MOD}+Shift+l`);
+    await expect(sidebar).toHaveClass(/toc-sidebar--collapsed/);
+  });
+
+  test("expand button opens sidebar when collapsed", async ({ page, loadApp }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: TOC_CONTENT,
+    });
+
+    const expandBtn = page.locator(".toc-expand-button");
+    await expect(expandBtn).toBeVisible();
+    await expandBtn.click();
+
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar).not.toHaveClass(/toc-sidebar--collapsed/);
+  });
+
+  test("sidebar displays headings with correct hierarchy", async ({ page, loadApp }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: TOC_CONTENT,
+    });
+
+    await page.keyboard.press(`${MOD}+Shift+l`);
+
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar.locator(".toc-sidebar__item")).toHaveCount(5, { timeout: 5_000 });
+
+    // Check heading text
+    const items = sidebar.locator(".toc-sidebar__item");
+    await expect(items.nth(0)).toContainText("Introduction");
+    await expect(items.nth(1)).toContainText("Background");
+    await expect(items.nth(2)).toContainText("Details");
+    await expect(items.nth(3)).toContainText("Architecture");
+    await expect(items.nth(4)).toContainText("Conclusion");
+  });
+
+  test("clicking a TOC entry scrolls to that heading", async ({ page, loadApp }) => {
+    // Use a long document so scrolling is needed
+    const longContent = TOC_CONTENT + "\n\nLots of filler text.\n".repeat(50) + "\n## Far Away Section\n\nEnd.\n";
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: longContent,
+    });
+
+    await page.keyboard.press(`${MOD}+Shift+l`);
+
+    // Wait for headings to populate
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar.locator(".toc-sidebar__item")).not.toHaveCount(0, { timeout: 5_000 });
+
+    // Click "Far Away Section"
+    await sidebar.locator(".toc-sidebar__item", { hasText: "Far Away Section" }).click();
+
+    // Wait briefly for rAF from scrollToHeading to fire
+    await page.waitForTimeout(500);
+
+    // Verify the heading is now visible within the scroll container.
+    // The scroll container is the overflow:auto div inside .editor-column.
+    // We poll until the heading's top is within the container's visible rect.
+    await expect
+      .poll(
+        async () => {
+          return page.evaluate(() => {
+            // Find the scroll container: first overflow:auto child in .editor-column
+            const editorColumn = document.querySelector(".editor-column") as HTMLElement | null;
+            if (!editorColumn) return false;
+            let container: HTMLElement | null = null;
+            for (const child of Array.from(editorColumn.children)) {
+              const s = window.getComputedStyle(child);
+              if (s.overflow === "auto" || s.overflowY === "auto" || s.overflow === "scroll" || s.overflowY === "scroll") {
+                container = child as HTMLElement;
+                break;
+              }
+            }
+            if (!container) return false;
+            const heading = document.querySelector(".milkdown .editor h2#far-away-section") as HTMLElement | null;
+            if (!heading) return false;
+            const containerRect = container.getBoundingClientRect();
+            const headingRect = heading.getBoundingClientRect();
+            return headingRect.top >= containerRect.top && headingRect.top < containerRect.bottom;
+          });
+        },
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+  });
+
+  test("TOC updates when a new heading is added", async ({ page, loadApp }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: "# First Heading\n\nSome text.\n",
+    });
+
+    await page.keyboard.press(`${MOD}+Shift+l`);
+
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar.locator(".toc-sidebar__item")).toHaveCount(1, { timeout: 5_000 });
+
+    // Click at the end of the editor and type a new heading
+    const editor = page.locator(".milkdown .editor");
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("## New Heading");
+
+    // Sidebar should update
+    await expect(sidebar.locator(".toc-sidebar__item")).toHaveCount(2, { timeout: 5_000 });
+    await expect(sidebar.locator(".toc-sidebar__item").nth(1)).toContainText("New Heading");
+  });
+
+  test("TOC works in source mode", async ({ page, loadApp }) => {
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: TOC_CONTENT,
+    });
+
+    // Switch to source mode
+    await page.keyboard.press(`${MOD}+m`);
+    await page.waitForSelector(".source-editor", { timeout: 5_000 });
+
+    // Open sidebar
+    await page.keyboard.press(`${MOD}+Shift+l`);
+
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar.locator(".toc-sidebar__item")).toHaveCount(5, { timeout: 5_000 });
+    await expect(sidebar.locator(".toc-sidebar__item").nth(0)).toContainText("Introduction");
+  });
+
+  test("click-to-navigate works in source mode", async ({ page, loadApp }) => {
+    const longContent = TOC_CONTENT + "\n\nFiller text.\n".repeat(50) + "\n## Far Away Section\n\nEnd.\n";
+    await loadApp({
+      openedFile: "/tmp/test.md",
+      fileContent: longContent,
+    });
+
+    // Switch to source mode
+    await page.keyboard.press(`${MOD}+m`);
+    await page.waitForSelector(".source-editor", { timeout: 5_000 });
+
+    // Open sidebar
+    await page.keyboard.press(`${MOD}+Shift+l`);
+
+    const sidebar = page.locator(".toc-sidebar");
+    await expect(sidebar.locator(".toc-sidebar__item")).not.toHaveCount(0, { timeout: 5_000 });
+
+    // Click "Far Away Section"
+    await sidebar.locator(".toc-sidebar__item", { hasText: "Far Away Section" }).click();
+
+    // Verify the cursor moved to the heading line
+    const cmContent = page.locator(".source-editor .cm-content");
+    await expect(cmContent).toContainText("Far Away Section");
+  });
+});

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -8,10 +8,12 @@ import { SourceEditor } from "./components/SourceEditor";
 import { SearchBar } from "./components/SearchBar";
 import { ErrorBanner } from "./components/ErrorBanner";
 import { ReloadBanner } from "./components/ReloadBanner";
+import { TocSidebar } from "./components/TocSidebar";
 import { useFile } from "./hooks/useFile";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useSearch } from "./hooks/useSearch";
 import { useTheme } from "./hooks/useTheme";
+import { useToc } from "./hooks/useToc";
 import { reinitMermaid } from "./plugins/mermaid-block";
 
 const PLACEHOLDER = `# Welcome to Skriv
@@ -44,10 +46,22 @@ function App() {
   const [syntaxToggling, setSyntaxToggling] = useState(true);
   const [sourceMode, setSourceMode] = useState(false);
   const [editorSnapshot, setEditorSnapshot] = useState<string | null>(null);
+  const [tocOpen, setTocOpen] = useState(() => {
+    return localStorage.getItem("skriv-toc-open") === "true";
+  });
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isModifiedRef = useRef(isModified);
   useEffect(() => {
     isModifiedRef.current = isModified;
   }, [isModified]);
+
+  useEffect(() => {
+    localStorage.setItem("skriv-toc-open", String(tocOpen));
+  }, [tocOpen]);
+
+  const handleToggleToc = useCallback(() => {
+    setTocOpen((prev) => !prev);
+  }, []);
 
   const handleChange = useCallback(() => {
     markModified();
@@ -127,6 +141,12 @@ function App() {
     handleToggleCaseSensitive,
   } = useSearch({ editorRef, sourceMode, getMilkdownCtx });
 
+  const { headings, activeIndex, scrollToHeading } = useToc({
+    editorRef,
+    sourceMode,
+    scrollContainerRef,
+  });
+
   useKeyboardShortcuts({
     onSave: handleSave,
     onSaveAs: handleSaveAs,
@@ -134,6 +154,7 @@ function App() {
     onToggleSyntax: handleToggleSyntax,
     onToggleSourceMode: handleToggleSourceMode,
     onSearch: openSearch,
+    onToggleToc: handleToggleToc,
   });
 
   useEffect(() => {
@@ -189,36 +210,57 @@ function App() {
         }}
         onDismiss={() => setShowReloadBanner(false)}
       />
-      <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
-        {isSearchOpen && (
-          <SearchBar
-            matchCount={searchInfo.matchCount}
-            activeIndex={searchInfo.activeIndex}
-            caseSensitive={searchInfo.caseSensitive}
-            initialQuery={initialQuery}
-            focusKey={focusKey}
-            onQueryChange={handleQueryChange}
-            onNext={handleNext}
-            onPrev={handlePrev}
-            onToggleCaseSensitive={handleToggleCaseSensitive}
-            onClose={closeSearch}
-          />
-        )}
-        <div style={{ height: "100%", overflow: "auto" }}>
-          {sourceMode ? (
-            <SourceEditor
-              ref={editorRef}
-              defaultValue={editorSnapshot ?? content ?? PLACEHOLDER}
-              onChange={handleChange}
-            />
-          ) : (
-            <MarkdownEditor
-              ref={editorRef}
-              defaultValue={editorSnapshot ?? content ?? PLACEHOLDER}
-              onChange={handleChange}
-              syntaxToggling={syntaxToggling}
+      <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+        <TocSidebar
+          headings={headings}
+          activeIndex={activeIndex}
+          isOpen={tocOpen}
+          onToggle={handleToggleToc}
+          onHeadingClick={scrollToHeading}
+        />
+        <div
+          className="editor-column"
+          style={{ flex: 1, position: "relative", overflow: "hidden" }}
+        >
+          {!tocOpen && (
+            <button
+              className="toc-expand-button"
+              onClick={handleToggleToc}
+              aria-label="Open table of contents"
+            >
+              ☰
+            </button>
+          )}
+          {isSearchOpen && (
+            <SearchBar
+              matchCount={searchInfo.matchCount}
+              activeIndex={searchInfo.activeIndex}
+              caseSensitive={searchInfo.caseSensitive}
+              initialQuery={initialQuery}
+              focusKey={focusKey}
+              onQueryChange={handleQueryChange}
+              onNext={handleNext}
+              onPrev={handlePrev}
+              onToggleCaseSensitive={handleToggleCaseSensitive}
+              onClose={closeSearch}
             />
           )}
+          <div ref={scrollContainerRef} style={{ height: "100%", overflow: "auto" }}>
+            {sourceMode ? (
+              <SourceEditor
+                ref={editorRef}
+                defaultValue={editorSnapshot ?? content ?? PLACEHOLDER}
+                onChange={handleChange}
+              />
+            ) : (
+              <MarkdownEditor
+                ref={editorRef}
+                defaultValue={editorSnapshot ?? content ?? PLACEHOLDER}
+                onChange={handleChange}
+                syntaxToggling={syntaxToggling}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/ui/__tests__/components/TocSidebar.test.tsx
+++ b/ui/__tests__/components/TocSidebar.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TocSidebar } from "../../components/TocSidebar";
+import type { TocHeading } from "../../types/toc";
+
+describe("TocSidebar", () => {
+  afterEach(cleanup);
+
+  const headings: TocHeading[] = [
+    { level: 1, text: "Introduction", pos: 0 },
+    { level: 2, text: "Background", pos: 50 },
+    { level: 2, text: "Motivation", pos: 120 },
+    { level: 1, text: "Conclusion", pos: 200 },
+  ];
+
+  const defaultProps = {
+    headings,
+    activeIndex: 0,
+    isOpen: true,
+    onToggle: vi.fn(),
+    onHeadingClick: vi.fn(),
+  };
+
+  it("renders all headings", () => {
+    render(<TocSidebar {...defaultProps} />);
+    expect(screen.getByText("Introduction")).not.toBeNull();
+    expect(screen.getByText("Background")).not.toBeNull();
+    expect(screen.getByText("Motivation")).not.toBeNull();
+    expect(screen.getByText("Conclusion")).not.toBeNull();
+  });
+
+  it("marks the active heading", () => {
+    render(<TocSidebar {...defaultProps} activeIndex={1} />);
+    const bg = screen.getByText("Background").closest("button");
+    expect(bg?.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("calls onHeadingClick with pos when heading is clicked", async () => {
+    const onHeadingClick = vi.fn();
+    render(<TocSidebar {...defaultProps} onHeadingClick={onHeadingClick} />);
+    await userEvent.click(screen.getByText("Background"));
+    expect(onHeadingClick).toHaveBeenCalledWith(50);
+  });
+
+  it("calls onToggle when collapse button is clicked", async () => {
+    const onToggle = vi.fn();
+    render(<TocSidebar {...defaultProps} onToggle={onToggle} />);
+    await userEvent.click(screen.getByLabelText("Collapse table of contents"));
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it("shows empty state when no headings", () => {
+    render(<TocSidebar {...defaultProps} headings={[]} />);
+    expect(screen.getByText("No headings")).not.toBeNull();
+  });
+
+  it("is hidden when isOpen is false", () => {
+    const { container } = render(<TocSidebar {...defaultProps} isOpen={false} />);
+    const sidebar = container.querySelector(".toc-sidebar");
+    expect(sidebar?.classList.contains("toc-sidebar--collapsed")).toBe(true);
+  });
+});

--- a/ui/__tests__/toc/extract-cm.test.ts
+++ b/ui/__tests__/toc/extract-cm.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { extractHeadingsFromText } from "../../toc/extract-cm";
+
+describe("extractHeadingsFromText", () => {
+  it("extracts headings with correct levels and positions", () => {
+    const text = "# Introduction\n\nSome text\n\n## Background\n";
+    const result = extractHeadingsFromText(text);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ level: 1, text: "Introduction", pos: 0 });
+    expect(result[1]).toEqual({ level: 2, text: "Background", pos: 27 });
+  });
+
+  it("handles all 6 heading levels", () => {
+    const text = "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n";
+    const result = extractHeadingsFromText(text);
+    expect(result).toHaveLength(6);
+    expect(result.map((h) => h.level)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("skips headings inside fenced code blocks", () => {
+    const text = "# Real Heading\n\n```\n# Not a heading\n```\n\n## Another Real\n";
+    const result = extractHeadingsFromText(text);
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("Real Heading");
+    expect(result[1].text).toBe("Another Real");
+  });
+
+  it("returns empty array for text with no headings", () => {
+    expect(extractHeadingsFromText("Just some text\n")).toEqual([]);
+  });
+
+  it("ignores lines with more than 6 hashes", () => {
+    const text = "####### Not a heading\n# Real\n";
+    const result = extractHeadingsFromText(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("Real");
+  });
+
+  it("handles headings with inline formatting markers", () => {
+    const text = "# **Bold** heading\n## *Italic* text\n";
+    const result = extractHeadingsFromText(text);
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("**Bold** heading");
+    expect(result[1].text).toBe("*Italic* text");
+  });
+});

--- a/ui/__tests__/toc/extract-pm.test.ts
+++ b/ui/__tests__/toc/extract-pm.test.ts
@@ -37,11 +37,7 @@ function paragraph(text: string) {
 
 describe("extractHeadingsFromPM", () => {
   it("extracts headings with correct levels and positions", () => {
-    const pmDoc = doc(
-      heading(1, "Introduction"),
-      paragraph("Some text"),
-      heading(2, "Background"),
-    );
+    const pmDoc = doc(heading(1, "Introduction"), paragraph("Some text"), heading(2, "Background"));
     const result = extractHeadingsFromPM(pmDoc);
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({ level: 1, text: "Introduction", pos: 0 });
@@ -49,10 +45,7 @@ describe("extractHeadingsFromPM", () => {
   });
 
   it("extracts heading_source nodes and strips ATX prefix", () => {
-    const pmDoc = doc(
-      headingSource(2, "## Editing"),
-      paragraph("body"),
-    );
+    const pmDoc = doc(headingSource(2, "## Editing"), paragraph("body"));
     const result = extractHeadingsFromPM(pmDoc);
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(expect.objectContaining({ level: 2, text: "Editing" }));
@@ -64,11 +57,7 @@ describe("extractHeadingsFromPM", () => {
   });
 
   it("handles mixed heading and heading_source nodes, stripping prefix from source", () => {
-    const pmDoc = doc(
-      heading(1, "Title"),
-      headingSource(2, "## Subtitle"),
-      heading(3, "Section"),
-    );
+    const pmDoc = doc(heading(1, "Title"), headingSource(2, "## Subtitle"), heading(3, "Section"));
     const result = extractHeadingsFromPM(pmDoc);
     expect(result).toHaveLength(3);
     expect(result.map((h) => h.level)).toEqual([1, 2, 3]);

--- a/ui/__tests__/toc/extract-pm.test.ts
+++ b/ui/__tests__/toc/extract-pm.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { Node, Schema } from "@milkdown/kit/prose/model";
+import { extractHeadingsFromPM } from "../../toc/extract-pm";
+
+const testSchema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*", toDOM: () => ["p", 0] },
+    heading: {
+      group: "block",
+      content: "inline*",
+      attrs: { level: { default: 1 }, id: { default: "" } },
+      toDOM: (node) => [`h${node.attrs.level}`, 0],
+    },
+    heading_source: {
+      group: "block",
+      content: "inline*",
+      attrs: { level: { default: 1 }, id: { default: "" } },
+      toDOM: (node) => [`h${node.attrs.level}`, 0],
+    },
+    text: { group: "inline" },
+  },
+});
+
+function doc(...children: Node[]) {
+  return testSchema.node("doc", null, children);
+}
+function heading(level: number, text: string) {
+  return testSchema.node("heading", { level }, text ? [testSchema.text(text)] : []);
+}
+function headingSource(level: number, text: string) {
+  return testSchema.node("heading_source", { level }, text ? [testSchema.text(text)] : []);
+}
+function paragraph(text: string) {
+  return testSchema.node("paragraph", null, text ? [testSchema.text(text)] : []);
+}
+
+describe("extractHeadingsFromPM", () => {
+  it("extracts headings with correct levels and positions", () => {
+    const pmDoc = doc(
+      heading(1, "Introduction"),
+      paragraph("Some text"),
+      heading(2, "Background"),
+    );
+    const result = extractHeadingsFromPM(pmDoc);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ level: 1, text: "Introduction", pos: 0 });
+    expect(result[1]).toEqual(expect.objectContaining({ level: 2, text: "Background" }));
+  });
+
+  it("extracts heading_source nodes and strips ATX prefix", () => {
+    const pmDoc = doc(
+      headingSource(2, "## Editing"),
+      paragraph("body"),
+    );
+    const result = extractHeadingsFromPM(pmDoc);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(expect.objectContaining({ level: 2, text: "Editing" }));
+  });
+
+  it("returns empty array for document with no headings", () => {
+    const pmDoc = doc(paragraph("Just text"));
+    expect(extractHeadingsFromPM(pmDoc)).toEqual([]);
+  });
+
+  it("handles mixed heading and heading_source nodes, stripping prefix from source", () => {
+    const pmDoc = doc(
+      heading(1, "Title"),
+      headingSource(2, "## Subtitle"),
+      heading(3, "Section"),
+    );
+    const result = extractHeadingsFromPM(pmDoc);
+    expect(result).toHaveLength(3);
+    expect(result.map((h) => h.level)).toEqual([1, 2, 3]);
+    expect(result.map((h) => h.text)).toEqual(["Title", "Subtitle", "Section"]);
+  });
+});

--- a/ui/components/TocSidebar.tsx
+++ b/ui/components/TocSidebar.tsx
@@ -1,0 +1,54 @@
+import type { TocHeading } from "../types/toc";
+
+interface TocSidebarProps {
+  headings: TocHeading[];
+  activeIndex: number;
+  isOpen: boolean;
+  onToggle: () => void;
+  onHeadingClick: (pos: number) => void;
+}
+
+const INDENT_PER_LEVEL = 12;
+
+export function TocSidebar({
+  headings,
+  activeIndex,
+  isOpen,
+  onToggle,
+  onHeadingClick,
+}: TocSidebarProps) {
+  return (
+    <div className={`toc-sidebar ${isOpen ? "" : "toc-sidebar--collapsed"}`}>
+      <div className="toc-sidebar__inner">
+        <div className="toc-sidebar__header">
+          <span className="toc-sidebar__title">Contents</span>
+          <button
+            className="toc-sidebar__toggle"
+            onClick={onToggle}
+            aria-label="Collapse table of contents"
+          >
+            ‹
+          </button>
+        </div>
+        <nav className="toc-sidebar__nav">
+          {headings.length === 0 ? (
+            <p className="toc-sidebar__empty">No headings</p>
+          ) : (
+            headings.map((heading, i) => (
+              <button
+                key={`${heading.pos}-${heading.text}`}
+                className={`toc-sidebar__item toc-sidebar__item--h${heading.level}`}
+                style={{ paddingLeft: `${8 + (heading.level - 1) * INDENT_PER_LEVEL}px` }}
+                aria-current={i === activeIndex ? "true" : undefined}
+                onClick={() => onHeadingClick(heading.pos)}
+                title={heading.text}
+              >
+                {heading.text}
+              </button>
+            ))
+          )}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/ui/hooks/useKeyboardShortcuts.ts
+++ b/ui/hooks/useKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ interface ShortcutHandlers {
   onToggleSyntax?: () => void;
   onToggleSourceMode?: () => void;
   onSearch?: () => void;
+  onToggleToc?: () => void;
 }
 
 export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
@@ -40,6 +41,9 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
       } else if (e.key === "m") {
         e.preventDefault();
         ref.current.onToggleSourceMode?.();
+      } else if (e.shiftKey && e.key === "l") {
+        e.preventDefault();
+        ref.current.onToggleToc?.();
       }
     };
 

--- a/ui/hooks/useToc.ts
+++ b/ui/hooks/useToc.ts
@@ -116,6 +116,10 @@ export function useToc({ editorRef, sourceMode, scrollContainerRef }: UseTocOpti
   }, [sourceMode, scrollContainerRef, editorRef]);
 
   // ── Click-to-navigate ───────────────────────────
+  // ProseMirror's tr.scrollIntoView() only scrolls its own DOM container,
+  // not the outer App scroll div. Use DOM scrollIntoView (rAF-deferred so
+  // decorations and position updates render first) instead — same pattern
+  // as useSearch.ts scrollActiveMatchIntoView.
   const scrollToHeading = useCallback(
     (pos: number) => {
       if (sourceMode) {
@@ -131,12 +135,40 @@ export function useToc({ editorRef, sourceMode, scrollContainerRef }: UseTocOpti
         if (!ctx) return;
         try {
           const view = ctx.get(editorViewCtx);
-          view.dispatch(
-            view.state.tr
-              .setSelection(TextSelection.create(view.state.doc, pos + 1))
-              .scrollIntoView()
-          );
+          // Move the cursor to the heading position
+          view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, pos + 1)));
           view.focus();
+          // Scroll the heading DOM node into view via the outer scroll container.
+          // ProseMirror's tr.scrollIntoView() only scrolls its own DOM container,
+          // not the outer App scroll div — use DOM scrollIntoView instead (same
+          // pattern as useSearch.ts scrollActiveMatchIntoView).
+          // rAF ensures the layout is stable before reading nodeDOM.
+          requestAnimationFrame(() => {
+            try {
+              const dom = view.nodeDOM(pos);
+              if (dom instanceof HTMLElement) {
+                dom.scrollIntoView({ block: "start", behavior: "instant" });
+              } else {
+                // nodeDOM can return null for nodes not in the rendered DOM.
+                // Fall back: resolve the heading text from the doc, derive its
+                // id attribute, and query the element directly.
+                const $pos = view.state.doc.resolve(pos + 1);
+                const node = $pos.parent;
+                const id = node.textContent
+                  .toLowerCase()
+                  .replace(/\s+/g, "-")
+                  .replace(/[^\w-]/g, "");
+                const el = view.dom.querySelector(
+                  `h1#${id}, h2#${id}, h3#${id}, h4#${id}, h5#${id}, h6#${id}`
+                ) as HTMLElement | null;
+                if (el) {
+                  el.scrollIntoView({ block: "start", behavior: "instant" });
+                }
+              }
+            } catch {
+              // Editor unmounted or pos invalid
+            }
+          });
         } catch {
           // Editor not ready
         }

--- a/ui/hooks/useToc.ts
+++ b/ui/hooks/useToc.ts
@@ -1,0 +1,154 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { RefObject } from "react";
+import { editorViewCtx } from "@milkdown/core";
+import { EditorView as CMEditorView } from "@codemirror/view";
+import { TextSelection } from "@milkdown/kit/prose/state";
+import type { EditorHandle } from "../types/editor";
+import type { TocHeading } from "../types/toc";
+import { extractHeadingsFromPM } from "../toc/extract-pm";
+import { extractHeadingsFromText } from "../toc/extract-cm";
+
+interface UseTocOptions {
+  editorRef: RefObject<EditorHandle | null>;
+  sourceMode: boolean;
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+}
+
+interface UseTocResult {
+  headings: TocHeading[];
+  activeIndex: number;
+  scrollToHeading: (pos: number) => void;
+}
+
+export function useToc({
+  editorRef,
+  sourceMode,
+  scrollContainerRef,
+}: UseTocOptions): UseTocResult {
+  const [headings, setHeadings] = useState<TocHeading[]>([]);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const headingsRef = useRef<TocHeading[]>([]);
+
+  useEffect(() => {
+    headingsRef.current = headings;
+  }, [headings]);
+
+  // ── Heading extraction ──────────────────────────
+  useEffect(() => {
+    if (sourceMode) {
+      // CodeMirror: poll for doc changes
+      const interval = setInterval(() => {
+        const view = editorRef.current?.getCodeMirrorView?.();
+        if (!view) return;
+        const text = view.state.doc.toString();
+        const next = extractHeadingsFromText(text);
+        setHeadings((prev) => {
+          if (JSON.stringify(prev) === JSON.stringify(next)) return prev;
+          return next;
+        });
+      }, 500);
+      return () => clearInterval(interval);
+    } else {
+      // ProseMirror: poll via ctx access
+      const interval = setInterval(() => {
+        const ctx = editorRef.current?.getMilkdownCtx?.();
+        if (!ctx) return;
+        try {
+          const view = ctx.get(editorViewCtx);
+          const next = extractHeadingsFromPM(view.state.doc);
+          setHeadings((prev) => {
+            if (JSON.stringify(prev) === JSON.stringify(next)) return prev;
+            return next;
+          });
+        } catch {
+          // Editor not ready yet
+        }
+      }, 500);
+      return () => clearInterval(interval);
+    }
+  }, [sourceMode, editorRef]);
+
+  // ── Scroll-spy ──────────────────────────────────
+  // Uses coordsAtPos (CM) and ProseMirror nodeDOM (PM) to find heading
+  // positions — avoids fragile DOM queries that break with virtualization
+  // or UI chrome elements.
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const onScroll = () => {
+      const threshold =
+        container.getBoundingClientRect().top + container.clientHeight * 0.2;
+      const current = headingsRef.current;
+      let active = -1;
+
+      if (sourceMode) {
+        // CodeMirror: use coordsAtPos which works with virtualized rendering
+        const view = editorRef.current?.getCodeMirrorView?.();
+        if (!view) return;
+
+        for (let i = 0; i < current.length; i++) {
+          const coords = view.coordsAtPos(current[i].pos);
+          if (!coords) continue;
+          if (coords.top <= threshold) active = i;
+        }
+      } else {
+        // ProseMirror: use the PM view to resolve each heading's pos to a
+        // DOM element, avoiding reliance on querySelectorAll index matching.
+        const ctx = editorRef.current?.getMilkdownCtx?.();
+        if (!ctx) return;
+        try {
+          const view = ctx.get(editorViewCtx);
+          for (let i = 0; i < current.length; i++) {
+            // nodeDOM takes the before-node position from doc.descendants
+            const dom = view.nodeDOM(current[i].pos);
+            if (!dom || !(dom instanceof HTMLElement)) continue;
+            const rect = dom.getBoundingClientRect();
+            if (rect.top <= threshold) active = i;
+          }
+        } catch {
+          // Editor not ready
+        }
+      }
+
+      setActiveIndex(active);
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+    // Run once on mount to set initial active
+    onScroll();
+    return () => container.removeEventListener("scroll", onScroll);
+  }, [sourceMode, scrollContainerRef, editorRef]);
+
+  // ── Click-to-navigate ───────────────────────────
+  const scrollToHeading = useCallback(
+    (pos: number) => {
+      if (sourceMode) {
+        const view = editorRef.current?.getCodeMirrorView?.();
+        if (!view) return;
+        view.dispatch({
+          selection: { anchor: pos },
+          effects: CMEditorView.scrollIntoView(pos, { y: "start", yMargin: 50 }),
+        });
+        view.focus();
+      } else {
+        const ctx = editorRef.current?.getMilkdownCtx?.();
+        if (!ctx) return;
+        try {
+          const view = ctx.get(editorViewCtx);
+          view.dispatch(
+            view.state.tr
+              .setSelection(TextSelection.create(view.state.doc, pos + 1))
+              .scrollIntoView(),
+          );
+          view.focus();
+        } catch {
+          // Editor not ready
+        }
+      }
+    },
+    [sourceMode, editorRef],
+  );
+
+  return { headings, activeIndex, scrollToHeading };
+}

--- a/ui/hooks/useToc.ts
+++ b/ui/hooks/useToc.ts
@@ -20,11 +20,7 @@ interface UseTocResult {
   scrollToHeading: (pos: number) => void;
 }
 
-export function useToc({
-  editorRef,
-  sourceMode,
-  scrollContainerRef,
-}: UseTocOptions): UseTocResult {
+export function useToc({ editorRef, sourceMode, scrollContainerRef }: UseTocOptions): UseTocResult {
   const [headings, setHeadings] = useState<TocHeading[]>([]);
   const [activeIndex, setActiveIndex] = useState(-1);
   const headingsRef = useRef<TocHeading[]>([]);
@@ -77,8 +73,7 @@ export function useToc({
     if (!container) return;
 
     const onScroll = () => {
-      const threshold =
-        container.getBoundingClientRect().top + container.clientHeight * 0.2;
+      const threshold = container.getBoundingClientRect().top + container.clientHeight * 0.2;
       const current = headingsRef.current;
       let active = -1;
 
@@ -139,7 +134,7 @@ export function useToc({
           view.dispatch(
             view.state.tr
               .setSelection(TextSelection.create(view.state.doc, pos + 1))
-              .scrollIntoView(),
+              .scrollIntoView()
           );
           view.focus();
         } catch {
@@ -147,7 +142,7 @@ export function useToc({
         }
       }
     },
-    [sourceMode, editorRef],
+    [sourceMode, editorRef]
   );
 
   return { headings, activeIndex, scrollToHeading };

--- a/ui/theme/skriv.css
+++ b/ui/theme/skriv.css
@@ -480,3 +480,127 @@ body,
   background: var(--crepe-color-primary, #4183c4);
   color: #fff;
 }
+
+/* ── TOC Sidebar ─────────────────────────────── */
+
+.toc-sidebar {
+  width: 220px;
+  min-width: 220px;
+  overflow: hidden;
+  transition:
+    width 0.2s ease,
+    min-width 0.2s ease;
+  border-right: 1px solid var(--crepe-color-outline, #eee);
+  background: var(--crepe-color-background, #ffffff);
+}
+
+.toc-sidebar--collapsed {
+  width: 0;
+  min-width: 0;
+  border-right: none;
+}
+
+.toc-sidebar__inner {
+  width: 220px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.toc-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 12px 8px;
+  flex-shrink: 0;
+}
+
+.toc-sidebar__title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--crepe-color-on-surface-variant, #666);
+}
+
+.toc-sidebar__toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: var(--crepe-color-on-surface-variant, #666);
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.toc-sidebar__toggle:hover {
+  background: var(--crepe-color-surface-variant, #f0f0f0);
+}
+
+.toc-sidebar__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 4px 12px;
+}
+
+.toc-sidebar__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--crepe-color-on-surface-variant, #555);
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.toc-sidebar__item:hover {
+  background: var(--crepe-color-surface-variant, #f0f0f0);
+  color: var(--crepe-color-on-surface, #333);
+}
+
+.toc-sidebar__item[aria-current="true"] {
+  background: var(--crepe-color-primary, #1976d2);
+  color: var(--crepe-color-on-primary, #fff);
+}
+
+.toc-sidebar__empty {
+  padding: 12px;
+  font-size: 12px;
+  color: var(--crepe-color-on-surface-variant, #999);
+  font-style: italic;
+}
+
+/* Expand button (visible when sidebar is collapsed) */
+.toc-expand-button {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 50;
+  background: var(--crepe-color-surface, #ffffff);
+  border: 1px solid var(--crepe-color-outline, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--crepe-color-on-surface-variant, #666);
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.toc-expand-button:hover {
+  background: var(--crepe-color-surface-variant, #f0f0f0);
+}
+
+/* Editor column container for future container queries (#11) */
+.editor-column {
+  container-name: editor;
+  container-type: inline-size;
+}

--- a/ui/toc/extract-cm.ts
+++ b/ui/toc/extract-cm.ts
@@ -1,0 +1,29 @@
+import type { TocHeading } from "../types/toc";
+
+const HEADING_RE = /^(#{1,6})\s+(.+)/;
+const FENCE_RE = /^(`{3,}|~{3,})/;
+
+export function extractHeadingsFromText(text: string): TocHeading[] {
+  const headings: TocHeading[] = [];
+  let inFence = false;
+  let offset = 0;
+
+  for (const line of text.split("\n")) {
+    const fenceMatch = FENCE_RE.exec(line);
+    if (fenceMatch) {
+      inFence = !inFence;
+    } else if (!inFence) {
+      const match = HEADING_RE.exec(line);
+      if (match) {
+        headings.push({
+          level: match[1].length,
+          text: match[2],
+          pos: offset,
+        });
+      }
+    }
+    offset += line.length + 1;
+  }
+
+  return headings;
+}

--- a/ui/toc/extract-pm.ts
+++ b/ui/toc/extract-pm.ts
@@ -1,0 +1,26 @@
+import type { Node } from "@milkdown/kit/prose/model";
+import type { TocHeading } from "../types/toc";
+
+const HEADING_TYPES = new Set(["heading", "heading_source"]);
+const ATX_PREFIX_RE = /^#{1,6}\s+/;
+
+/** Strip the leading `## ` ATX prefix that heading_source nodes include in textContent. */
+function stripAtxPrefix(text: string): string {
+  return text.replace(ATX_PREFIX_RE, "");
+}
+
+export function extractHeadingsFromPM(doc: Node): TocHeading[] {
+  const headings: TocHeading[] = [];
+  doc.descendants((node, pos) => {
+    if (HEADING_TYPES.has(node.type.name)) {
+      const raw = node.textContent;
+      headings.push({
+        level: node.attrs.level as number,
+        text: node.type.name === "heading_source" ? stripAtxPrefix(raw) : raw,
+        pos,
+      });
+      return false;
+    }
+  });
+  return headings;
+}

--- a/ui/types/toc.ts
+++ b/ui/types/toc.ts
@@ -1,0 +1,5 @@
+export interface TocHeading {
+  level: number; // 1-6
+  text: string; // heading text content
+  pos: number; // editor offset (PM doc position or CM line offset)
+}


### PR DESCRIPTION
## Summary

Closes #19

- Adds a collapsible left sidebar displaying a table of contents derived from document headings (h1–h6), with indentation reflecting hierarchy
- Click-to-navigate scrolls the editor to the selected heading; scroll-spy highlights the currently visible heading
- Works in both WYSIWYG (Milkdown/ProseMirror) and source (CodeMirror) mode
- Toggle via `Cmd+Shift+L` keyboard shortcut or expand/collapse button; state persists in localStorage
- Editor column uses CSS `container-type: inline-size` to support future responsive breakpoints (#11)

## New Files

- `ui/types/toc.ts` — shared `TocHeading` interface
- `ui/toc/extract-pm.ts` — ProseMirror heading extraction (strips ATX prefix from `heading_source` nodes)
- `ui/toc/extract-cm.ts` — CodeMirror heading extraction (skips fenced code blocks)
- `ui/components/TocSidebar.tsx` — presentational sidebar component
- `ui/hooks/useToc.ts` — hook bridging extraction, scroll-spy, and click-to-navigate

## Test Plan

- [ ] `make check` passes (363 unit tests, 18 Rust tests, format, lint, typecheck)
- [ ] `pnpm test:e2e` passes (48 tests including 7 new TOC sidebar tests)
- [ ] Open a markdown file with headings, press `Cmd+Shift+L` — sidebar appears with headings
- [ ] Click a heading in sidebar — editor scrolls to it
- [ ] Scroll the editor — active heading highlights in sidebar
- [ ] Add/remove headings — sidebar updates in real time
- [ ] Switch to source mode — sidebar still works with click-to-navigate
- [ ] Close and reopen app — sidebar remembers open/closed state