### PR TITLE
feat: multi-window and single-instance support (#5)

### DIFF
--- a/docs/plans/2026-03-27-multi-window-single-instance-design.md
+++ b/docs/plans/2026-03-27-multi-window-single-instance-design.md
@@ -1,0 +1,162 @@
+# Multi-Window and Single-Instance Support
+
+**Issue:** #5
+**Date:** 2026-03-27
+**Status:** Design
+
+## Summary
+
+Support opening multiple files in separate windows while maintaining a single application instance. Each window is independent with its own file state, watcher, and editor. The app behaves like a native macOS editor — Cmd+N for blank windows, Cmd+O for opening files, single-instance detection to prevent duplicate processes, and unsaved-changes dialogs on close.
+
+## Backend State Model
+
+Replace the global `OpenedFile` and `FileWatcher` singletons with a central `WindowManager`:
+
+```rust
+struct WindowState {
+    file_path: Option<PathBuf>,              // None for blank windows; always canonical
+    watcher: Option<RecommendedWatcher>,
+    watched_path: Option<PathBuf>,
+    last_self_write: Arc<Mutex<Option<Instant>>>,
+    debounce_tx: Option<std::sync::mpsc::Sender<()>>,
+}
+
+struct WindowManager {
+    windows: Mutex<HashMap<String, WindowState>>,
+    next_id: AtomicU64,                      // monotonic counter for unique window labels
+}
+```
+
+- Registered as `tauri::State<WindowManager>`, replacing both `OpenedFile` and `FileWatcher`
+- Entry created when a window is opened, removed on close
+- Existing `FileWatcher` logic (debounce, self-write suppression) moves into `WindowState` methods
+- All commands gain the window label via `tauri::Window` parameter — Tauri provides this automatically
+- The initial window created by `tauri.conf.json` is labeled `"main"`; dynamically created windows use `"window-{next_id}"`. The `WindowManager` handles both label styles uniformly
+- File paths stored in `WindowState` are always canonicalized (via `ValidatedPath`) so the already-open check works correctly across symlinks and relative paths
+
+## Window Lifecycle
+
+### Creating Windows
+
+A `create_window()` Rust helper calls `WebviewWindowBuilder::new()` with a unique label from `WindowManager.next_id`, sets default size (900x700) and title ("Untitled"), and inserts a new `WindowState` entry into the `WindowManager` map. The webview URL is resolved from the Tauri app config (respecting dev server vs. production dist). If a file path is provided, the file is opened immediately after creation.
+
+Three creation paths:
+
+1. **Cmd+N** — Frontend invokes `create_window` command with no file path. Creates a blank window.
+2. **Cmd+O from existing window** — Frontend invokes `create_window` with the selected file path. Opens in the current window if it's blank and unmodified (i.e., `path === null && isModified === false`).
+3. **External open** (Finder, CLI, single-instance plugin) — Rust-side creates a new window with the file path.
+
+### Closing Windows
+
+- Listen for Tauri's `close_requested` via `getCurrentWindow().onCloseRequested()` in the frontend
+- If `isModified`, call `event.preventDefault()` and show the macOS-standard save/don't-save/cancel sheet via `tauri-plugin-dialog`
+- On confirmed close, frontend invokes `close_window` command which cleans up the `WindowState` entry (stops watcher, removes from map) and destroys the window from the Rust side
+- When the last window closes, the app quits (standard macOS quit behavior; staying alive with zero windows is a future consideration)
+
+### App Quit (Cmd+Q)
+
+Intercept `RunEvent::ExitRequested` in the Rust `.run()` callback. When received:
+
+1. Call `event.prevent_exit()`
+2. Iterate all windows in `WindowManager` and emit a `quit-requested` event to each
+3. Each frontend window handles this the same as `close_requested` — show save/don't-save/cancel if modified
+4. Each window reports back (via a `window-close-confirmed` command) when resolved
+5. Once all windows have confirmed, call `app_handle.exit(0)`
+
+If any window cancels, the quit is aborted.
+
+### Already-Open Check
+
+When opening a file, `WindowManager` scans existing entries for a matching `file_path` (compared on canonicalized paths). If found, that window is focused instead of creating a duplicate.
+
+## Single-Instance Support
+
+Uses `tauri-plugin-single-instance` (v2.x, new dependency — cross-platform, uses platform-specific IPC).
+
+When a second Skriv process launches (e.g., double-clicking another `.md` file), the plugin detects the existing instance and forwards the CLI args. The existing instance receives a callback, extracts file paths, and either focuses the window that already has that file open or creates a new window.
+
+The existing `RunEvent::Opened { urls }` handler (macOS file associations) calls the same create-or-focus logic instead of emitting to a fixed "main" window.
+
+CLI args on first launch use the same shared path — parse args, create window(s) for each file (note: current code only handles one file; this extends to multiple). If no files are provided, create one blank window.
+
+All three entry points (first launch, single-instance callback, macOS `Opened` event) converge on one function: given a list of file paths, open or focus windows for them.
+
+## Command Changes
+
+### Modified Commands
+
+| Command | Change |
+|---------|--------|
+| `read_file` | No state change — already stateless |
+| `write_file` | Looks up `WindowState` by window label to record self-write on the correct watcher |
+| `write_new_file` | After writing, updates `WindowState.file_path` for the calling window, starts a watcher, and expands asset scope. (This fixes an existing gap where Save As didn't set up watching.) |
+| `get_file_info` | No change — stateless query |
+| `watch_file` | Creates watcher in the calling window's `WindowState` |
+| `unwatch_file` | Cleans up watcher in the calling window's `WindowState` |
+| `get_opened_file` | Looks up the calling window's `file_path` from `WindowManager` |
+
+### New Commands
+
+| Command | Purpose |
+|---------|---------|
+| `create_window` | Creates a new window, optionally with a file path. Returns the new window label. |
+| `close_window` | Cleans up `WindowState` for the calling window (stops watcher, removes entry). Destroys the window. |
+
+The frontend code for each window doesn't change significantly. Each window still calls the same commands — the backend routes to the correct `WindowState` using the window label Tauri provides automatically.
+
+**Event targeting:** The file watcher currently uses `app_handle.emit()` which broadcasts to all windows. This must change to `app_handle.emit_to(label, ...)` so `file-changed` events only reach the window watching that specific file.
+
+## Frontend Changes
+
+Each Tauri window gets its own webview with its own React app instance, so all hooks (`useFile`, `useSearch`, `useTheme`, etc.) are naturally per-window already.
+
+### What Changes
+
+1. **Cmd+N handler** — Added to `useKeyboardShortcuts`. Invokes `create_window` command.
+2. **Cmd+O behavior** — If the current window is blank and unmodified, open in place. Otherwise, invoke `create_window` with the selected path.
+3. **Close handling** — `close_requested` listener in `App.tsx`. If not modified: invoke `close_window`. If modified: show save/don't-save/cancel dialog. Save → save then close. Don't Save → close. Cancel → prevent close.
+4. **`file-opened` event listener removed** — Rust backend handles external file opens directly by creating windows.
+
+### What Stays the Same
+
+- `useFile`, `useSearch`, `useTheme`, editor components — all unchanged
+- Window title updates — already per-window via `getCurrentWindow().setTitle()`
+- All keyboard shortcuts except Cmd+N and Cmd+O
+
+## Asset Scope and Security
+
+The asset protocol scope is global and additive — files opened in different windows accumulate scope entries. This is acceptable behavior; a file opened in one window making images from that directory visible to another window matches how browsers handle same-origin resources. No changes needed to `ValidatedPath` or `scope.rs`.
+
+The `default.json` capability currently targets the `"main"` window and must be updated to `"windows": ["*"]` so dynamically created windows receive the same permissions.
+
+## Testing Strategy
+
+### Rust Unit Tests
+
+- `WindowManager` — insert/remove/lookup window state, already-open detection
+- `WindowState` — watcher lifecycle, self-write suppression (existing watcher tests adapted)
+- Command tests — verify commands route to correct `WindowState` by window label
+
+### Integration Tests (Tauri)
+
+- Single-instance callback correctly creates windows
+- CLI args parsed into window creation calls
+- Window close cleans up state
+
+### Frontend Tests (Vitest)
+
+- Close-requested handler logic (modified vs. unmodified paths)
+- Cmd+N / Cmd+O routing logic (blank window vs. new window)
+
+### E2E Tests (Playwright)
+
+- Open file → opens in window
+- Cmd+N → blank window appears
+- Open same file twice → focuses existing window instead of duplicate
+- Close with unsaved changes → dialog appears
+
+## Future Considerations
+
+The `WindowManager` with its `HashMap<String, WindowState>` is designed to evolve toward tabs. When tabs are added, the key shifts from window label to a nested structure (window → tabs → file state). The state map pattern scales to this naturally without architectural replacement.
+
+**Not in scope:** Native menu bar (File > New, Window menu listing open files). Rely on keyboard shortcuts and macOS window switching (Cmd+`, Mission Control) for now.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3667,6 +3667,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tempfile",
 ]
 
@@ -4128,6 +4129,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-clipboard-manager = "2.3.2"
 notify = "8"
+tauri-plugin-single-instance = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,11 +1,15 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
+  "description": "Capability for all windows",
+  "windows": ["*"],
   "permissions": [
     "core:default",
     "core:window:allow-set-title",
+    "core:window:allow-create",
+    "core:window:allow-destroy",
+    "core:window:allow-close",
+    "core:window:allow-set-focus",
     "opener:default",
     "dialog:default",
     "clipboard-manager:allow-read-text"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::validated_path::ValidatedPath;
+use tauri::Manager;
 
 /// Format a file operation error with the validated path context.
 fn file_error(op: &str, path: &ValidatedPath, err: impl std::fmt::Display) -> String {
@@ -24,17 +25,39 @@ fn write_validated(validated: &ValidatedPath, content: &str) -> Result<(), Strin
 pub fn write_file(
     path: String,
     content: String,
-    watcher: tauri::State<'_, crate::watcher::FileWatcher>,
+    window: tauri::Window,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
 ) -> Result<(), String> {
     let validated = ValidatedPath::new(&path)?;
-    watcher.record_self_write();
+    manager.get_state(window.label(), |state| {
+        state.record_self_write();
+    });
     write_validated(&validated, &content)
 }
 
 #[tauri::command]
-pub fn write_new_file(path: String, content: String) -> Result<(), String> {
+pub fn write_new_file(
+    path: String,
+    content: String,
+    window: tauri::Window,
+    app_handle: tauri::AppHandle,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
+) -> Result<(), String> {
     let validated = ValidatedPath::new_for_write(&path)?;
-    write_validated(&validated, &content)
+    write_validated(&validated, &content)?;
+
+    // After successful write, update backend state
+    let canonical = validated.as_path().to_path_buf();
+    let label = window.label().to_string();
+    manager.set_file_path(&label, Some(canonical));
+    crate::scope::expand_scope_for_file(&app_handle, validated.as_path())?;
+    manager
+        .with_state_mut(&label, |state| {
+            state.watch(&path, label.clone(), app_handle.clone())
+        })
+        .unwrap_or(Ok(()))?;
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -73,24 +96,99 @@ pub struct FileInfo {
 }
 
 #[tauri::command]
-pub fn get_opened_file(state: tauri::State<'_, crate::OpenedFile>) -> Option<String> {
-    state.0.lock().unwrap().clone()
+pub fn get_opened_file(
+    window: tauri::Window,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
+) -> Option<String> {
+    manager
+        .get_state(window.label(), |state| {
+            state
+                .file_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+        })
+        .flatten()
 }
 
 #[tauri::command]
 pub fn watch_file(
     path: String,
+    window: tauri::Window,
     app_handle: tauri::AppHandle,
-    watcher: tauri::State<'_, crate::watcher::FileWatcher>,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
 ) -> Result<(), String> {
-    // Validate path before watching (prevent using watcher as filesystem probe)
     crate::validated_path::ValidatedPath::new(&path)?;
-    watcher.watch(&path, app_handle)
+    let label = window.label().to_string();
+    manager
+        .with_state_mut(&label, |state| {
+            state.watch(&path, label.clone(), app_handle.clone())
+        })
+        .unwrap_or(Err("Window not found".to_string()))
 }
 
 #[tauri::command]
-pub fn unwatch_file(watcher: tauri::State<'_, crate::watcher::FileWatcher>) -> Result<(), String> {
-    watcher.unwatch()
+pub fn unwatch_file(
+    window: tauri::Window,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
+) -> Result<(), String> {
+    manager
+        .with_state_mut(window.label(), |state| state.unwatch())
+        .unwrap_or(Ok(()))
+}
+
+#[tauri::command]
+pub async fn create_window(
+    path: Option<String>,
+    app_handle: tauri::AppHandle,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
+) -> Result<String, String> {
+    // Check if the file is already open in another window
+    let canonical = if let Some(ref p) = path {
+        let validated = ValidatedPath::new(p)?;
+        let c = validated.as_path().to_path_buf();
+        if let Some(existing_label) = manager.find_by_path(&c) {
+            if let Some(win) = app_handle.get_webview_window(&existing_label) {
+                let _ = win.set_focus();
+            }
+            return Ok(existing_label);
+        }
+        Some(c)
+    } else {
+        None
+    };
+
+    let label = manager.next_label();
+    crate::window_manager::WindowManager::build_window(&app_handle, &label)?;
+    manager.register(&label);
+
+    if let Some(c) = canonical {
+        manager.set_file_path(&label, Some(c));
+    }
+
+    Ok(label)
+}
+
+#[tauri::command]
+pub async fn close_window(
+    window: tauri::Window,
+    manager: tauri::State<'_, crate::window_manager::WindowManager>,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+
+    manager.with_state_mut(&label, |state| {
+        let _ = state.unwatch();
+    });
+    manager.remove(&label);
+
+    window
+        .destroy()
+        .map_err(|e| format!("Failed to close window: {}", e))?;
+
+    if manager.window_count() == 0 {
+        window.app_handle().exit(0);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -147,10 +245,8 @@ mod tests {
     fn test_write_new_file() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("new.md");
-        let result = write_new_file(
-            file_path.to_string_lossy().to_string(),
-            "# New file".to_string(),
-        );
+        let validated = ValidatedPath::new_for_write(&file_path.to_string_lossy()).unwrap();
+        let result = write_validated(&validated, "# New file");
         assert!(result.is_ok());
         assert_eq!(fs::read_to_string(&file_path).unwrap(), "# New file");
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,15 +1,10 @@
 mod commands;
 mod scope;
 mod validated_path;
-mod watcher;
+pub(crate) mod watcher;
+pub mod window_manager;
 
-use std::sync::Mutex;
-#[cfg(target_os = "macos")]
-use tauri::Emitter;
-use tauri::Manager;
-
-#[derive(Default)]
-pub struct OpenedFile(pub Mutex<Option<String>>);
+use tauri::{Emitter, Manager};
 
 fn resolve_file_path(arg: &str) -> Option<std::path::PathBuf> {
     if arg.starts_with('-') {
@@ -20,13 +15,9 @@ fn resolve_file_path(arg: &str) -> Option<std::path::PathBuf> {
     } else {
         std::path::PathBuf::from(arg)
     };
-    // Try canonicalizing directly (works for absolute paths and paths
-    // relative to the current working directory)
     if let Ok(canonical) = path.canonicalize() {
         return Some(canonical);
     }
-    // In Tauri dev mode, CWD may be the src-tauri/ directory rather than
-    // the repo root. Try resolving relative to the parent directory.
     if path.is_relative() {
         if let Ok(cwd) = std::env::current_dir() {
             if let Some(parent) = cwd.parent() {
@@ -40,14 +31,66 @@ fn resolve_file_path(arg: &str) -> Option<std::path::PathBuf> {
     None
 }
 
+fn open_or_focus_paths(app: &tauri::AppHandle, paths: Vec<std::path::PathBuf>) {
+    let manager = app.state::<window_manager::WindowManager>();
+
+    if paths.is_empty() {
+        let label = manager.next_label();
+        if window_manager::WindowManager::build_window(app, &label).is_ok() {
+            manager.register(&label);
+        }
+        return;
+    }
+
+    for path in paths {
+        let canonical = match path.canonicalize() {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        if let Some(existing_label) = manager.find_by_path(&canonical) {
+            if let Some(win) = app.get_webview_window(&existing_label) {
+                let _ = win.set_focus();
+            }
+            continue;
+        }
+
+        // Reuse a blank window if one exists (e.g., setup created one before
+        // macOS Opened event arrived with the file path)
+        if let Some(blank_label) = manager.find_blank() {
+            let path_str = canonical.to_string_lossy().into_owned();
+            manager.set_file_path(&blank_label, Some(canonical));
+            if let Some(win) = app.get_webview_window(&blank_label) {
+                let _ = win.set_focus();
+                // Tell the already-loaded frontend to open the file
+                let _ = win.emit("file-opened", path_str);
+            }
+            continue;
+        }
+
+        let label = manager.next_label();
+        if window_manager::WindowManager::build_window(app, &label).is_ok() {
+            manager.register(&label);
+            manager.set_file_path(&label, Some(canonical));
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .manage(OpenedFile::default())
-        .manage(watcher::FileWatcher::new())
+        .manage(window_manager::WindowManager::new())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            let paths: Vec<std::path::PathBuf> = argv
+                .iter()
+                .skip(1)
+                .filter_map(|arg| resolve_file_path(arg))
+                .collect();
+            open_or_focus_paths(app, paths);
+        }))
         .invoke_handler(tauri::generate_handler![
             commands::read_file,
             commands::write_file,
@@ -56,36 +99,68 @@ pub fn run() {
             commands::get_opened_file,
             commands::watch_file,
             commands::unwatch_file,
+            commands::create_window,
+            commands::close_window,
         ])
         .setup(|app| {
-            for arg in std::env::args().skip(1) {
-                if let Some(path) = resolve_file_path(&arg) {
-                    let state = app.state::<OpenedFile>();
-                    *state.0.lock().unwrap() = Some(path.to_string_lossy().into_owned());
-                    break;
-                }
+            let paths: Vec<std::path::PathBuf> = std::env::args()
+                .skip(1)
+                .filter_map(|arg| resolve_file_path(&arg))
+                .collect();
+
+            if !paths.is_empty() {
+                // CLI args have file paths — open them now
+                open_or_focus_paths(app.handle(), paths);
+            } else {
+                // No CLI args. On macOS, file associations deliver paths via
+                // RunEvent::Opened (not CLI args), so defer blank window creation
+                // to MainEventsCleared to give Opened a chance to fire first.
+                // On other platforms, create the blank window immediately.
+                #[cfg(not(target_os = "macos"))]
+                open_or_focus_paths(app.handle(), vec![]);
             }
+
             Ok(())
         })
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
-        .run(|app, event| {
-            #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Opened { urls } = event {
-                if let Some(url) = urls.first() {
-                    if let Ok(path) = url.to_file_path() {
-                        let path_str = path.to_string_lossy().into_owned();
-                        let state = app.state::<OpenedFile>();
-                        *state.0.lock().unwrap() = Some(path_str.clone());
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("file-opened", path_str);
+        .run({
+            let mut needs_initial_window = true;
+            move |app, event| {
+                match event {
+                    #[cfg(target_os = "macos")]
+                    tauri::RunEvent::Opened { urls } => {
+                        needs_initial_window = false;
+                        let paths: Vec<std::path::PathBuf> = urls
+                            .iter()
+                            .filter_map(|url| url.to_file_path().ok())
+                            .collect();
+                        open_or_focus_paths(app, paths);
+                    }
+                    tauri::RunEvent::MainEventsCleared if needs_initial_window => {
+                        // After the first batch of events, if no window was created
+                        // (no CLI args, no macOS Opened event), create a blank one.
+                        needs_initial_window = false;
+                        let manager = app.state::<window_manager::WindowManager>();
+                        if manager.window_count() == 0 {
+                            open_or_focus_paths(app, vec![]);
                         }
                     }
+                    tauri::RunEvent::ExitRequested { api, code, .. } => {
+                        if code.is_some() {
+                            return;
+                        }
+                        api.prevent_exit();
+                        let manager = app.state::<window_manager::WindowManager>();
+                        let labels = manager.labels();
+                        for label in labels {
+                            if let Some(win) = app.get_webview_window(&label) {
+                                let _ = win.emit("quit-requested", ());
+                            }
+                        }
+                    }
+                    _ => {}
                 }
-            }
-            #[cfg(not(target_os = "macos"))]
-            {
-                let _ = (app, event);
             }
         });
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,101 +1,8 @@
-use notify::{recommended_watcher, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter};
-
-const SELF_WRITE_SUPPRESSION_MS: u64 = 1000;
-const DEBOUNCE_MS: u64 = 300;
-
-pub struct FileWatcher {
-    watcher: Mutex<Option<RecommendedWatcher>>,
-    watched_path: Mutex<Option<PathBuf>>,
-    last_self_write: Arc<Mutex<Option<Instant>>>,
-    debounce_tx: Mutex<Option<std::sync::mpsc::Sender<()>>>,
-}
-
-impl FileWatcher {
-    pub fn new() -> Self {
-        Self {
-            watcher: Mutex::new(None),
-            watched_path: Mutex::new(None),
-            last_self_write: Arc::new(Mutex::new(None)),
-            debounce_tx: Mutex::new(None),
-        }
-    }
-
-    pub fn record_self_write(&self) {
-        *self.last_self_write.lock().unwrap() = Some(Instant::now());
-    }
-
-    pub fn watch(&self, path: &str, app_handle: AppHandle) -> Result<(), String> {
-        self.unwatch()?;
-
-        let path = PathBuf::from(path);
-        let canonical = path
-            .canonicalize()
-            .map_err(|e| format!("Failed to resolve path: {}", e))?;
-
-        let emit_path = canonical.to_string_lossy().into_owned();
-        let last_self_write_ref = self.last_self_write.clone();
-
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        // Spawn debounce thread
-        std::thread::spawn(move || {
-            run_debounce_loop(rx, Duration::from_millis(DEBOUNCE_MS), move || {
-                let suppress = {
-                    let last = last_self_write_ref.lock().unwrap();
-                    last.is_some_and(|t| {
-                        t.elapsed() < Duration::from_millis(SELF_WRITE_SUPPRESSION_MS)
-                    })
-                };
-                if !suppress {
-                    let _ = app_handle.emit("file-changed", &emit_path);
-                }
-            });
-        });
-
-        let tx_clone = tx.clone();
-        let mut watcher = recommended_watcher(move |res: Result<Event, _>| {
-            if let Ok(event) = res {
-                if matches!(event.kind, EventKind::Modify(_)) {
-                    let _ = tx_clone.send(());
-                }
-            }
-        })
-        .map_err(|e| format!("Failed to create watcher: {}", e))?;
-
-        watcher
-            .watch(canonical.as_ref(), RecursiveMode::NonRecursive)
-            .map_err(|e| format!("Failed to watch '{}': {}", canonical.display(), e))?;
-
-        *self.watcher.lock().unwrap() = Some(watcher);
-        *self.watched_path.lock().unwrap() = Some(canonical);
-        *self.debounce_tx.lock().unwrap() = Some(tx);
-
-        Ok(())
-    }
-
-    pub fn unwatch(&self) -> Result<(), String> {
-        let mut watcher = self.watcher.lock().unwrap();
-        let mut watched = self.watched_path.lock().unwrap();
-
-        if let (Some(w), Some(p)) = (watcher.as_mut(), watched.as_ref()) {
-            let _ = w.unwatch(p.as_ref());
-        }
-
-        *watcher = None;
-        *watched = None;
-        *self.debounce_tx.lock().unwrap() = None; // drops sender, terminates debounce thread
-
-        Ok(())
-    }
-}
+use std::time::Duration;
 
 /// Debounce loop: waits for signals on `rx`, then waits for `quiet_period` of
 /// silence before calling `on_emit`. Exits when the sender is dropped.
-fn run_debounce_loop(
+pub fn run_debounce_loop(
     rx: std::sync::mpsc::Receiver<()>,
     quiet_period: Duration,
     mut on_emit: impl FnMut(),
@@ -122,6 +29,7 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::mpsc;
+    use std::sync::Arc;
 
     #[test]
     fn debounce_coalesces_rapid_signals() {

--- a/src-tauri/src/window_manager.rs
+++ b/src-tauri/src/window_manager.rs
@@ -1,0 +1,261 @@
+use notify::{recommended_watcher, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter};
+
+const SELF_WRITE_SUPPRESSION_MS: u64 = 1000;
+const DEBOUNCE_MS: u64 = 300;
+
+pub struct WindowState {
+    pub file_path: Option<PathBuf>,
+    pub watcher: Option<RecommendedWatcher>,
+    pub watched_path: Option<PathBuf>,
+    pub last_self_write: Arc<Mutex<Option<Instant>>>,
+    pub debounce_tx: Option<std::sync::mpsc::Sender<()>>,
+}
+
+impl Default for WindowState {
+    fn default() -> Self {
+        Self {
+            file_path: None,
+            watcher: None,
+            watched_path: None,
+            last_self_write: Arc::new(Mutex::new(None)),
+            debounce_tx: None,
+        }
+    }
+}
+
+impl WindowState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_self_write(&self) {
+        *self.last_self_write.lock().unwrap() = Some(Instant::now());
+    }
+
+    pub fn watch(
+        &mut self,
+        path: &str,
+        label: String,
+        app_handle: AppHandle,
+    ) -> Result<(), String> {
+        self.unwatch()?;
+
+        let path = PathBuf::from(path);
+        let canonical = path
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve path: {}", e))?;
+
+        let emit_path = canonical.to_string_lossy().into_owned();
+        let last_self_write_ref = self.last_self_write.clone();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            crate::watcher::run_debounce_loop(rx, Duration::from_millis(DEBOUNCE_MS), move || {
+                let suppress = {
+                    let last = last_self_write_ref.lock().unwrap();
+                    last.is_some_and(|t| {
+                        t.elapsed() < Duration::from_millis(SELF_WRITE_SUPPRESSION_MS)
+                    })
+                };
+                if !suppress {
+                    let _ = app_handle.emit_to(&label, "file-changed", &emit_path);
+                }
+            });
+        });
+
+        let tx_clone = tx.clone();
+        let mut watcher = recommended_watcher(move |res: Result<notify::Event, _>| {
+            if let Ok(event) = res {
+                if matches!(event.kind, EventKind::Modify(_)) {
+                    let _ = tx_clone.send(());
+                }
+            }
+        })
+        .map_err(|e| format!("Failed to create watcher: {}", e))?;
+
+        watcher
+            .watch(canonical.as_ref(), RecursiveMode::NonRecursive)
+            .map_err(|e| format!("Failed to watch '{}': {}", canonical.display(), e))?;
+
+        self.watcher = Some(watcher);
+        self.watched_path = Some(canonical);
+        self.debounce_tx = Some(tx);
+
+        Ok(())
+    }
+
+    pub fn unwatch(&mut self) -> Result<(), String> {
+        if let (Some(w), Some(p)) = (self.watcher.as_mut(), self.watched_path.as_ref()) {
+            let _ = w.unwatch(p.as_ref());
+        }
+        self.watcher = None;
+        self.watched_path = None;
+        self.debounce_tx = None;
+        Ok(())
+    }
+}
+
+pub struct WindowManager {
+    windows: Mutex<HashMap<String, WindowState>>,
+    next_id: AtomicU64,
+}
+
+impl Default for WindowManager {
+    fn default() -> Self {
+        Self {
+            windows: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(0),
+        }
+    }
+}
+
+impl WindowManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Generate the next unique window label.
+    pub fn next_label(&self) -> String {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        format!("window-{}", id)
+    }
+
+    /// Register a new window with empty state.
+    pub fn register(&self, label: &str) {
+        let mut windows = self.windows.lock().unwrap();
+        windows.insert(label.to_string(), WindowState::new());
+    }
+
+    /// Remove a window's state. Returns true if it existed.
+    pub fn remove(&self, label: &str) -> bool {
+        let mut windows = self.windows.lock().unwrap();
+        windows.remove(label).is_some()
+    }
+
+    /// Access a window's state within a closure. Returns None if not found.
+    pub fn get_state<R>(&self, label: &str, f: impl FnOnce(&WindowState) -> R) -> Option<R> {
+        let windows = self.windows.lock().unwrap();
+        windows.get(label).map(f)
+    }
+
+    /// Mutably access a window's state within a closure. Returns None if not found.
+    pub fn with_state_mut<R>(
+        &self,
+        label: &str,
+        f: impl FnOnce(&mut WindowState) -> R,
+    ) -> Option<R> {
+        let mut windows = self.windows.lock().unwrap();
+        windows.get_mut(label).map(f)
+    }
+
+    /// Set the file path for a window.
+    pub fn set_file_path(&self, label: &str, path: Option<PathBuf>) {
+        self.with_state_mut(label, |state| {
+            state.file_path = path;
+        });
+    }
+
+    /// Find a window with no file open (blank window).
+    pub fn find_blank(&self) -> Option<String> {
+        let windows = self.windows.lock().unwrap();
+        for (label, state) in windows.iter() {
+            if state.file_path.is_none() {
+                return Some(label.clone());
+            }
+        }
+        None
+    }
+
+    /// Find the window label that has a given file path open.
+    pub fn find_by_path(&self, path: &Path) -> Option<String> {
+        let windows = self.windows.lock().unwrap();
+        for (label, state) in windows.iter() {
+            if state.file_path.as_deref() == Some(path) {
+                return Some(label.clone());
+            }
+        }
+        None
+    }
+
+    /// Return the number of registered windows.
+    pub fn window_count(&self) -> usize {
+        self.windows.lock().unwrap().len()
+    }
+
+    /// Get all window labels.
+    pub fn labels(&self) -> Vec<String> {
+        self.windows.lock().unwrap().keys().cloned().collect()
+    }
+
+    /// Build a new webview window with standard configuration and focus it.
+    pub fn build_window(
+        app: &tauri::AppHandle,
+        label: &str,
+    ) -> Result<tauri::WebviewWindow, String> {
+        let url = tauri::WebviewUrl::App("index.html".into());
+        let window = tauri::webview::WebviewWindowBuilder::new(app, label, url)
+            .title("Untitled")
+            .inner_size(900.0, 700.0)
+            .build()
+            .map_err(|e| format!("Failed to create window: {}", e))?;
+        let _ = window.set_focus();
+        Ok(window)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_and_remove_window() {
+        let mgr = WindowManager::new();
+        mgr.register("win-0");
+        assert!(mgr.get_state("win-0", |_| ()).is_some());
+
+        mgr.remove("win-0");
+        assert!(mgr.get_state("win-0", |_| ()).is_none());
+    }
+
+    #[test]
+    fn next_label_increments() {
+        let mgr = WindowManager::new();
+        assert_eq!(mgr.next_label(), "window-0");
+        assert_eq!(mgr.next_label(), "window-1");
+    }
+
+    #[test]
+    fn find_by_path_returns_matching_label() {
+        let mgr = WindowManager::new();
+        mgr.register("win-0");
+        let target = PathBuf::from("/docs/test.md");
+        mgr.set_file_path("win-0", Some(target.clone()));
+
+        assert_eq!(mgr.find_by_path(&target), Some("win-0".to_string()));
+        assert_eq!(mgr.find_by_path(&PathBuf::from("/other.md")), None);
+    }
+
+    #[test]
+    fn remove_nonexistent_is_noop() {
+        let mgr = WindowManager::new();
+        mgr.remove("no-such-window"); // should not panic
+    }
+
+    #[test]
+    fn window_count() {
+        let mgr = WindowManager::new();
+        assert_eq!(mgr.window_count(), 0);
+        mgr.register("a");
+        mgr.register("b");
+        assert_eq!(mgr.window_count(), 2);
+        mgr.remove("a");
+        assert_eq!(mgr.window_count(), 1);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,13 +10,7 @@
     "frontendDist": "../ui/dist"
   },
   "app": {
-    "windows": [
-      {
-        "title": "Skriv",
-        "width": 900,
-        "height": 700
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https:; connect-src 'self'",
       "assetProtocol": {

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -12,6 +12,7 @@ import { useFile } from "./hooks/useFile";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useSearch } from "./hooks/useSearch";
 import { useTheme } from "./hooks/useTheme";
+import { useWindowClose } from "./hooks/useWindowClose";
 import { reinitMermaid } from "./plugins/mermaid-block";
 
 const PLACEHOLDER = `# Welcome to Skriv
@@ -48,6 +49,10 @@ function App() {
   useEffect(() => {
     isModifiedRef.current = isModified;
   }, [isModified]);
+  const pathRef = useRef(path);
+  useEffect(() => {
+    pathRef.current = path;
+  }, [path]);
 
   const handleChange = useCallback(() => {
     markModified();
@@ -83,12 +88,22 @@ function App() {
     await saveFile(markdown);
   }, [path, saveFile, handleSaveAs]);
 
+  const handleNewWindow = useCallback(async () => {
+    await invoke("create_window");
+  }, []);
+
   const handleOpen = useCallback(async () => {
     const selected = await open({
       filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
     });
-    if (selected) {
+    if (!selected) return;
+
+    if (!pathRef.current) {
+      // Current window has no file — open in place
       openFile(selected as string);
+    } else {
+      // Current window has a file — open in a new window
+      await invoke("create_window", { path: selected });
     }
   }, [openFile]);
 
@@ -131,9 +146,15 @@ function App() {
     onSave: handleSave,
     onSaveAs: handleSaveAs,
     onOpen: handleOpen,
+    onNewWindow: handleNewWindow,
     onToggleSyntax: handleToggleSyntax,
     onToggleSourceMode: handleToggleSourceMode,
     onSearch: openSearch,
+  });
+
+  useWindowClose({
+    isModified,
+    onSave: handleSave,
   });
 
   useEffect(() => {

--- a/ui/__tests__/hooks/useWindowClose.test.ts
+++ b/ui/__tests__/hooks/useWindowClose.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { invoke, resetTauriMocks } from "../mocks/tauri";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+// vi.hoisted ensures these are available when vi.mock factories run (hoisted above imports)
+const { mockOnCloseRequested, mockMessage } = vi.hoisted(() => ({
+  mockOnCloseRequested: vi.fn(() => Promise.resolve(vi.fn())),
+  mockMessage: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    onCloseRequested: mockOnCloseRequested,
+  }),
+}));
+
+import { listen } from "../mocks/tauri";
+vi.mock("@tauri-apps/api/event", () => ({ listen }));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  message: mockMessage,
+}));
+
+import { useWindowClose } from "../../hooks/useWindowClose";
+
+describe("useWindowClose", () => {
+  beforeEach(() => {
+    resetTauriMocks();
+    mockOnCloseRequested.mockReset().mockReturnValue(Promise.resolve(vi.fn()));
+    mockMessage.mockReset();
+  });
+
+  it("registers close_requested listener on mount", () => {
+    renderHook(() =>
+      useWindowClose({
+        isModified: false,
+        onSave: vi.fn(),
+      })
+    );
+
+    expect(mockOnCloseRequested).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers quit-requested listener on mount", () => {
+    renderHook(() =>
+      useWindowClose({
+        isModified: false,
+        onSave: vi.fn(),
+      })
+    );
+
+    expect(listen).toHaveBeenCalledWith("quit-requested", expect.any(Function));
+  });
+});

--- a/ui/hooks/useKeyboardShortcuts.ts
+++ b/ui/hooks/useKeyboardShortcuts.ts
@@ -4,6 +4,7 @@ interface ShortcutHandlers {
   onSave: () => void;
   onSaveAs: () => void;
   onOpen: () => void;
+  onNewWindow?: () => void;
   onToggleSyntax?: () => void;
   onToggleSourceMode?: () => void;
   onSearch?: () => void;
@@ -22,6 +23,12 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
       if (e.key === "f" && !e.shiftKey) {
         e.preventDefault();
         ref.current.onSearch?.();
+        return;
+      }
+
+      if (e.key === "n" && !e.shiftKey) {
+        e.preventDefault();
+        ref.current.onNewWindow?.();
         return;
       }
 

--- a/ui/hooks/useWindowClose.ts
+++ b/ui/hooks/useWindowClose.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { message } from "@tauri-apps/plugin-dialog";
+
+interface UseWindowCloseOptions {
+  isModified: boolean;
+  onSave: () => Promise<void>;
+}
+
+export function useWindowClose({ isModified, onSave }: UseWindowCloseOptions) {
+  const isModifiedRef = useRef(isModified);
+  useEffect(() => {
+    isModifiedRef.current = isModified;
+  }, [isModified]);
+
+  const onSaveRef = useRef(onSave);
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  async function handleUnsavedChanges() {
+    // Custom button labels return the label text as the result, not "Yes"/"No"/"Cancel"
+    const SAVE = "Save";
+    const DONT_SAVE = "Don't Save";
+    const CANCEL = "Cancel";
+
+    const result = await message("Do you want to save your changes?", {
+      title: "Unsaved Changes",
+      kind: "warning",
+      buttons: { yes: SAVE, no: DONT_SAVE, cancel: CANCEL },
+    });
+
+    if (result === SAVE) {
+      await onSaveRef.current();
+      await invoke("close_window");
+    } else if (result === DONT_SAVE) {
+      await invoke("close_window");
+    }
+    // "Cancel" or dialog dismissed → do nothing, keep window open
+  }
+
+  useEffect(() => {
+    const unlisten = getCurrentWindow().onCloseRequested(async (event) => {
+      // Always prevent native close — we manage it via close_window command
+      event.preventDefault();
+
+      if (!isModifiedRef.current) {
+        await invoke("close_window");
+        return;
+      }
+      await handleUnsavedChanges();
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen("quit-requested", async () => {
+      if (!isModifiedRef.current) {
+        await invoke("close_window");
+        return;
+      }
+      await handleUnsavedChanges();
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- Replace global `OpenedFile` and `FileWatcher` singletons with a per-window `WindowManager` keyed by window label
- Each window gets independent file state, watcher, and editor via its own `WindowState` entry
- Single-instance detection via `tauri-plugin-single-instance` — opening a file while Skriv is running creates a new window in the existing process
- macOS file association support — double-clicking `.md` files opens them in Skriv
- Cmd+N creates a new blank window, Cmd+O opens in a new window when the current window has a file
- Three-way unsaved changes dialog (Save / Don't Save / Cancel) on window close and Cmd+Q
- Cmd+Q intercepts `ExitRequested` to prompt each dirty window before quitting

## Test plan

- [x] All 349 frontend tests pass
- [x] All 23 Rust tests pass
- [x] `make check` passes (format, lint, typecheck, clippy, tests)
- [x] Open file from Finder — single window with file (no extra blank window)
- [x] Cmd+N creates a new blank window
- [x] Cmd+O from blank window opens file in place
- [x] Close modified window shows Save/Don't Save/Cancel dialog
- [x] Cmd+O from window with file opens in new window
- [x] Open same file twice focuses existing window
- [x] Cmd+Q with multiple dirty windows prompts each one
- [x] `skriv file.md` from CLI while app is running opens in existing process

Closes #5